### PR TITLE
Restore MQTT access inventory and stabilize Lighthouse

### DIFF
--- a/docs/analyzer/data-collection-access.fr.md
+++ b/docs/analyzer/data-collection-access.fr.md
@@ -8,8 +8,8 @@ task: understand-observer-data
 scope: canada-baseline
 status: draft
 owner: meshcore-canada
-last_reviewed: 2026-07-22
-review_by: 2026-10-19
+last_reviewed: 2026-09-02
+review_by: 2026-12-01
 difficulty: beginner
 estimated_time: 6 minutes
 destructive: false
@@ -69,6 +69,21 @@ paquets.
 MeshCore Canada n’offre pas d’abonnement direct général au courtier. L’accès
 direct est limité à CoreScope, aux administrateurs des réseaux maillés locaux
 et aux personnes autorisées par les administrateurs de l’infrastructure.
+
+## Comptes MQTT en lecture seule
+
+Cet inventaire public répertorie les services qui utilisent un compte en lecture
+seule sur les courtiers MQTT de MeshCore Canada. Il indique le service et
+l’exploitant, mais jamais le nom d’utilisateur MQTT, le mot de passe ni le jeton.
+
+| Service | Exploitant | Utilisation |
+|---|---|---|
+| Beacon (`dev.meshcore.ca`) | Exploitants de MeshCore Canada | Visualisation publique des paquets et vérification des identifiants de répéteur |
+| CoreScope (`live.meshcore.ca`) | Exploitants de MeshCore Canada | Outils publics pour les observateurs, les paquets, les nœuds et la carte |
+
+Les administrateurs de l’infrastructure doivent mettre ce tableau à jour chaque
+fois qu’ils créent ou retirent un compte en lecture seule. [Signalez une entrée
+manquante ou périmée](https://github.com/MeshCore-ca/MeshCore-Canada/issues/new/choose).
 
 ## Où les données apparaissent
 

--- a/docs/analyzer/data-collection-access.md
+++ b/docs/analyzer/data-collection-access.md
@@ -8,8 +8,8 @@ task: understand-observer-data
 scope: canada-baseline
 status: draft
 owner: meshcore-canada
-last_reviewed: 2026-07-22
-review_by: 2026-10-19
+last_reviewed: 2026-09-02
+review_by: 2026-12-01
 difficulty: beginner
 estimated_time: 6 minutes
 destructive: false
@@ -59,6 +59,17 @@ Changing the radio preset changes what the observer can hear. Public and private
 | Broker credentials | Authenticate the observer | Should remain only in the local integration | Local operator and authentication service | Never include in public diagnostics |
 
 MeshCore Canada does not offer general direct broker subscriptions. Direct access is limited to CoreScope, local mesh administrators, and people approved by the infrastructure administrators.
+
+## Read-only MQTT accounts
+
+This public inventory lists services with a read-only account on the MeshCore Canada brokers. It identifies the service and operator, but never publishes broker usernames, passwords, or tokens.
+
+| Service | Operator | Purpose |
+|---|---|---|
+| Beacon (`dev.meshcore.ca`) | MeshCore Canada operators | Public packet viewer and repeater ID checks |
+| CoreScope (`live.meshcore.ca`) | MeshCore Canada operators | Public observer, packet, node, and map tools |
+
+Infrastructure administrators must update this table whenever they create or remove a read-only account. [Report a missing or outdated entry](https://github.com/MeshCore-ca/MeshCore-Canada/issues/new/choose).
 
 ## Where it appears
 

--- a/scripts/run-lighthouse.mjs
+++ b/scripts/run-lighthouse.mjs
@@ -69,6 +69,17 @@ async function run() {
     chromeFlags: ["--headless=new", "--no-sandbox", "--disable-dev-shm-usage"]
   });
 
+  // A fresh Chrome process can make the first CI audit a cold-start outlier.
+  // Warm it once, then enforce the unchanged budgets on every measured route.
+  const warmupUrl = resolveSiteRoute(baseUrl, routes[0][1]);
+  const warmup = await lighthouse(warmupUrl, {
+    port: chrome.port,
+    output: "json",
+    logLevel: "error",
+    onlyCategories: ["performance"]
+  }, desktopConfig);
+  if (!warmup) throw new Error(`Lighthouse warm-up returned no result for ${warmupUrl}`);
+
   const failures = [];
   for (const [name, route] of routes) {
     const url = resolveSiteRoute(baseUrl, route);

--- a/tests/content/analyzer-journey.test.mjs
+++ b/tests/content/analyzer-journey.test.mjs
@@ -113,17 +113,25 @@ test("all observer method guides follow one lifecycle and end in live verificati
   }
 });
 
-test("privacy page states ownership, access, and the unknown retention boundary", () => {
+test("privacy pages state ownership, access, the account inventory, and the unknown retention boundary", () => {
   const source = read("docs/analyzer/data-collection-access.md");
+  const french = read("docs/analyzer/data-collection-access.fr.md");
   for (const phrase of [
     "Policy summary",
     "MeshCore Canada infrastructure administrators",
     "Collection, access, and retention",
+    "Read-only MQTT accounts",
     "public retention period has not yet been published",
     "Never include in public diagnostics",
   ]) {
     assert.match(source, new RegExp(phrase, "i"));
   }
+  for (const service of ["Beacon (`dev.meshcore.ca`)", "CoreScope (`live.meshcore.ca`)"]) {
+    assert.ok(source.includes(service), `English inventory missing ${service}`);
+    assert.ok(french.includes(service), `French inventory missing ${service}`);
+  }
+  assert.match(source, /update this table whenever they create or remove a read-only account/i);
+  assert.match(french, /mettre ce tableau à jour chaque\s+fois qu’ils créent ou retirent un compte en lecture seule/i);
 });
 
 test("verification distinguishes connectivity from an observed packet", () => {


### PR DESCRIPTION
## What changed

- restores the public read-only MQTT account inventory for Beacon and CoreScope in English and French
- makes the inventory maintenance rule explicit while keeping usernames, passwords, and tokens out of the site
- warms Lighthouse once before measured routes so a cold Chrome startup cannot sink only the first page
- keeps the existing Lighthouse budgets unchanged and adds a regression check for the bilingual inventory

## Why

The post-merge run for PR #86 failed only the first Lighthouse measurement: the English home page scored 0.73, while the next six routes scored 0.97 to 1.00. Validation passed and the full browser job passed. This fixes the cold-start measurement without weakening the quality gate.

Failed run: https://github.com/MeshCore-ca/MeshCore-Canada/actions/runs/33650486354/job/100316356666

## Local verification

- `npm run test:content` — 73 passed
- `npm run audit:lighthouse` — home 1.00; other performance scores 0.96 to 1.00; all budgets passed
- `npm run test:browser:chromium` — 66 passed, 5 skipped
- strict bilingual build and built-link audit passed