### PR TITLE
Restore broker administrator contacts

### DIFF
--- a/docs/analyzer/broker-reference.fr.md
+++ b/docs/analyzer/broker-reference.fr.md
@@ -8,8 +8,8 @@ task: reference-observer-endpoints
 scope: canada-baseline
 status: draft
 owner: meshcore-canada
-last_reviewed: 2026-07-22
-review_by: 2026-10-19
+last_reviewed: 2026-09-02
+review_by: 2026-12-01
 difficulty: advanced
 estimated_time: 8 minutes
 destructive: false
@@ -49,6 +49,17 @@ Ces valeurs proviennent de la [configuration commune des observateurs](observer-
 </div>
 
 Si le tableau ne s’affiche pas, ouvrez [observer-config.json](observer-config.json).
+
+## Administrateurs des courtiers
+
+Communiquez avec un administrateur pour demander un accès en lecture seule ou signaler un problème de compte. N’envoyez jamais de mot de passe ni de jeton.
+
+| Administrateur | Contact |
+|---|---|
+| n30nex | [GitHub : @n30nex](https://github.com/n30nex) |
+| Mr. Alderson | [GitHub : @MrAlders0n](https://github.com/MrAlders0n) |
+| Ded | [GitHub : @446564](https://github.com/446564) |
+| Kranic | [Forum MeshCore : @djkranic](https://forum.meshcore.ca/u/djkranic) |
 
 ## Modèles de sujets
 

--- a/docs/analyzer/broker-reference.md
+++ b/docs/analyzer/broker-reference.md
@@ -8,8 +8,8 @@ task: reference-observer-endpoints
 scope: canada-baseline
 status: draft
 owner: meshcore-canada
-last_reviewed: 2026-07-22
-review_by: 2026-10-19
+last_reviewed: 2026-09-02
+review_by: 2026-12-01
 difficulty: advanced
 estimated_time: 8 minutes
 destructive: false
@@ -48,6 +48,17 @@ These values come from the shared [observer configuration](observer-config.json)
 </div>
 
 If the table does not load, open [observer-config.json](observer-config.json).
+
+## Broker administrators
+
+Contact an administrator to request read-only access or report an account problem. Never send passwords or tokens.
+
+| Administrator | Contact |
+|---|---|
+| n30nex | [GitHub: @n30nex](https://github.com/n30nex) |
+| Mr. Alderson | [GitHub: @MrAlders0n](https://github.com/MrAlders0n) |
+| Ded | [GitHub: @446564](https://github.com/446564) |
+| Kranic | [MeshCore forum: @djkranic](https://forum.meshcore.ca/u/djkranic) |
 
 ## Topic templates
 

--- a/docs/analyzer/data-collection-access.fr.md
+++ b/docs/analyzer/data-collection-access.fr.md
@@ -8,7 +8,7 @@ task: understand-observer-data
 scope: canada-baseline
 status: draft
 owner: meshcore-canada
-last_reviewed: 2026-09-02
+last_reviewed: 2026-09-03
 review_by: 2026-12-01
 difficulty: beginner
 estimated_time: 6 minutes
@@ -72,14 +72,15 @@ et aux personnes autorisées par les administrateurs de l’infrastructure.
 
 ## Comptes MQTT en lecture seule
 
-Cet inventaire public répertorie les services qui utilisent un compte en lecture
-seule sur les courtiers MQTT de MeshCore Canada. Il indique le service et
-l’exploitant, mais jamais le nom d’utilisateur MQTT, le mot de passe ni le jeton.
+Cet inventaire public répertorie les services qui disposent d’un accès en lecture
+seule aux courtiers MQTT de MeshCore Canada. Il indique le service et
+l’exploitant, mais jamais les mots de passe ni les jetons.
 
 | Service | Exploitant | Utilisation |
 |---|---|---|
 | Beacon (`dev.meshcore.ca`) | Exploitants de MeshCore Canada | Visualisation publique des paquets et vérification des identifiants de répéteur |
 | CoreScope (`live.meshcore.ca`) | Exploitants de MeshCore Canada | Outils publics pour les observateurs, les paquets, les nœuds et la carte |
+| [Quinte Mesh](https://quintemesh.ca/) | hansimgamr | Services du réseau communautaire de la région de Quinte |
 
 Les administrateurs de l’infrastructure doivent mettre ce tableau à jour chaque
 fois qu’ils créent ou retirent un compte en lecture seule. [Signalez une entrée

--- a/docs/analyzer/data-collection-access.md
+++ b/docs/analyzer/data-collection-access.md
@@ -8,7 +8,7 @@ task: understand-observer-data
 scope: canada-baseline
 status: draft
 owner: meshcore-canada
-last_reviewed: 2026-09-02
+last_reviewed: 2026-09-03
 review_by: 2026-12-01
 difficulty: beginner
 estimated_time: 6 minutes
@@ -62,12 +62,13 @@ MeshCore Canada does not offer general direct broker subscriptions. Direct acces
 
 ## Read-only MQTT accounts
 
-This public inventory lists services with a read-only account on the MeshCore Canada brokers. It identifies the service and operator, but never publishes broker usernames, passwords, or tokens.
+This public inventory lists services with read-only access to the MeshCore Canada brokers. It identifies the service and operator, but never publishes passwords or tokens.
 
 | Service | Operator | Purpose |
 |---|---|---|
 | Beacon (`dev.meshcore.ca`) | MeshCore Canada operators | Public packet viewer and repeater ID checks |
 | CoreScope (`live.meshcore.ca`) | MeshCore Canada operators | Public observer, packet, node, and map tools |
+| [Quinte Mesh](https://quintemesh.ca/) | hansimgamr | Quinte-region community network services |
 
 Infrastructure administrators must update this table whenever they create or remove a read-only account. [Report a missing or outdated entry](https://github.com/MeshCore-ca/MeshCore-Canada/issues/new/choose).
 

--- a/tests/content/analyzer-journey.test.mjs
+++ b/tests/content/analyzer-journey.test.mjs
@@ -134,6 +134,24 @@ test("privacy pages state ownership, access, the account inventory, and the unkn
   assert.match(french, /mettre ce tableau à jour chaque\s+fois qu’ils créent ou retirent un compte en lecture seule/i);
 });
 
+test("broker reference lists every administrator and public contact in both languages", () => {
+  const english = read("docs/analyzer/broker-reference.md");
+  const french = read("docs/analyzer/broker-reference.fr.md");
+  const contacts = [
+    ["n30nex", "https://github.com/n30nex"],
+    ["Mr. Alderson", "https://github.com/MrAlders0n"],
+    ["Ded", "https://github.com/446564"],
+    ["Kranic", "https://forum.meshcore.ca/u/djkranic"],
+  ];
+
+  for (const [administrator, contact] of contacts) {
+    for (const page of [english, french]) {
+      assert.ok(page.includes(administrator), `missing administrator ${administrator}`);
+      assert.ok(page.includes(contact), `missing contact ${contact}`);
+    }
+  }
+});
+
 test("verification distinguishes connectivity from an observed packet", () => {
   const source = read("docs/analyzer/verify.md");
   assert.match(source, /broker connection proves only/i);

--- a/tests/content/analyzer-journey.test.mjs
+++ b/tests/content/analyzer-journey.test.mjs
@@ -126,10 +126,16 @@ test("privacy pages state ownership, access, the account inventory, and the unkn
   ]) {
     assert.match(source, new RegExp(phrase, "i"));
   }
-  for (const service of ["Beacon (`dev.meshcore.ca`)", "CoreScope (`live.meshcore.ca`)"]) {
+  for (const service of [
+    "Beacon (`dev.meshcore.ca`)",
+    "CoreScope (`live.meshcore.ca`)",
+    "[Quinte Mesh](https://quintemesh.ca/)",
+  ]) {
     assert.ok(source.includes(service), `English inventory missing ${service}`);
     assert.ok(french.includes(service), `French inventory missing ${service}`);
   }
+  assert.ok(source.includes("hansimgamr"), "English inventory missing the Quinte Mesh operator");
+  assert.ok(french.includes("hansimgamr"), "French inventory missing the Quinte Mesh operator");
   assert.match(source, /update this table whenever they create or remove a read-only account/i);
   assert.match(french, /mettre ce tableau à jour chaque\s+fois qu’ils créent ou retirent un compte en lecture seule/i);
 });


### PR DESCRIPTION
## Summary

- restore the broker administrator contact table on the English and French broker reference pages
- list n30nex, Mr. Alderson, Ded, and Kranic with their public contact profiles
- add Quinte Mesh and operator `hansimgamr` to the bilingual read-only MQTT access inventory
- keep passwords and tokens out of the documentation
- add regression coverage so the administrator and access lists cannot disappear unnoticed

## Validation

- `npm run test:content` — 74 passed
- `npm run check:links` — strict bilingual build; 128 pages and 12,683 local references passed
