### PR TITLE
Restore lost guide content and broker access references

### DIFF
--- a/docs/analyzer/broker-reference.fr.md
+++ b/docs/analyzer/broker-reference.fr.md
@@ -8,8 +8,8 @@ task: reference-observer-endpoints
 scope: canada-baseline
 status: draft
 owner: meshcore-canada
-last_reviewed: 2026-07-22
-review_by: 2026-10-19
+last_reviewed: 2026-09-02
+review_by: 2026-12-01
 difficulty: advanced
 estimated_time: 8 minutes
 destructive: false
@@ -49,6 +49,17 @@ Ces valeurs proviennent de la [configuration commune des observateurs](observer-
 </div>
 
 Si le tableau ne s’affiche pas, ouvrez [observer-config.json](observer-config.json).
+
+## Administrateurs des courtiers
+
+Communiquez avec un administrateur pour demander un accès en lecture seule ou signaler un problème de compte. N’envoyez jamais de mot de passe ni de jeton.
+
+| Administrateur | Contact |
+|---|---|
+| n30nex | [GitHub : @n30nex](https://github.com/n30nex) |
+| Mr. Alderson | [GitHub : @MrAlders0n](https://github.com/MrAlders0n) |
+| Ded | [GitHub : @446564](https://github.com/446564) |
+| Kranic | [Forum MeshCore : @djkranic](https://forum.meshcore.ca/u/djkranic) |
 
 ## Modèles de sujets
 

--- a/docs/analyzer/broker-reference.md
+++ b/docs/analyzer/broker-reference.md
@@ -8,8 +8,8 @@ task: reference-observer-endpoints
 scope: canada-baseline
 status: draft
 owner: meshcore-canada
-last_reviewed: 2026-07-22
-review_by: 2026-10-19
+last_reviewed: 2026-09-02
+review_by: 2026-12-01
 difficulty: advanced
 estimated_time: 8 minutes
 destructive: false
@@ -48,6 +48,17 @@ These values come from the shared [observer configuration](observer-config.json)
 </div>
 
 If the table does not load, open [observer-config.json](observer-config.json).
+
+## Broker administrators
+
+Contact an administrator to request read-only access or report an account problem. Never send passwords or tokens.
+
+| Administrator | Contact |
+|---|---|
+| n30nex | [GitHub: @n30nex](https://github.com/n30nex) |
+| Mr. Alderson | [GitHub: @MrAlders0n](https://github.com/MrAlders0n) |
+| Ded | [GitHub: @446564](https://github.com/446564) |
+| Kranic | [MeshCore forum: @djkranic](https://forum.meshcore.ca/u/djkranic) |
 
 ## Topic templates
 

--- a/docs/analyzer/data-collection-access.fr.md
+++ b/docs/analyzer/data-collection-access.fr.md
@@ -8,7 +8,7 @@ task: understand-observer-data
 scope: canada-baseline
 status: draft
 owner: meshcore-canada
-last_reviewed: 2026-09-02
+last_reviewed: 2026-09-03
 review_by: 2026-12-01
 difficulty: beginner
 estimated_time: 6 minutes
@@ -72,14 +72,15 @@ et aux personnes autorisées par les administrateurs de l’infrastructure.
 
 ## Comptes MQTT en lecture seule
 
-Cet inventaire public répertorie les services qui utilisent un compte en lecture
-seule sur les courtiers MQTT de MeshCore Canada. Il indique le service et
-l’exploitant, mais jamais le nom d’utilisateur MQTT, le mot de passe ni le jeton.
+Cet inventaire public répertorie les services qui disposent d’un accès en lecture
+seule aux courtiers MQTT de MeshCore Canada. Il indique le service et
+l’exploitant, mais jamais les mots de passe ni les jetons.
 
 | Service | Exploitant | Utilisation |
 |---|---|---|
 | Beacon (`dev.meshcore.ca`) | Exploitants de MeshCore Canada | Visualisation publique des paquets et vérification des identifiants de répéteur |
 | CoreScope (`live.meshcore.ca`) | Exploitants de MeshCore Canada | Outils publics pour les observateurs, les paquets, les nœuds et la carte |
+| [Quinte Mesh](https://quintemesh.ca/) | hansimgamr | Services du réseau communautaire de la région de Quinte |
 
 Les administrateurs de l’infrastructure doivent mettre ce tableau à jour chaque
 fois qu’ils créent ou retirent un compte en lecture seule. [Signalez une entrée

--- a/docs/analyzer/data-collection-access.md
+++ b/docs/analyzer/data-collection-access.md
@@ -8,7 +8,7 @@ task: understand-observer-data
 scope: canada-baseline
 status: draft
 owner: meshcore-canada
-last_reviewed: 2026-09-02
+last_reviewed: 2026-09-03
 review_by: 2026-12-01
 difficulty: beginner
 estimated_time: 6 minutes
@@ -62,12 +62,13 @@ MeshCore Canada does not offer general direct broker subscriptions. Direct acces
 
 ## Read-only MQTT accounts
 
-This public inventory lists services with a read-only account on the MeshCore Canada brokers. It identifies the service and operator, but never publishes broker usernames, passwords, or tokens.
+This public inventory lists services with read-only access to the MeshCore Canada brokers. It identifies the service and operator, but never publishes passwords or tokens.
 
 | Service | Operator | Purpose |
 |---|---|---|
 | Beacon (`dev.meshcore.ca`) | MeshCore Canada operators | Public packet viewer and repeater ID checks |
 | CoreScope (`live.meshcore.ca`) | MeshCore Canada operators | Public observer, packet, node, and map tools |
+| [Quinte Mesh](https://quintemesh.ca/) | hansimgamr | Quinte-region community network services |
 
 Infrastructure administrators must update this table whenever they create or remove a read-only account. [Report a missing or outdated entry](https://github.com/MeshCore-ca/MeshCore-Canada/issues/new/choose).
 

--- a/docs/hardware/recommended-antenna.fr.md
+++ b/docs/hardware/recommended-antenna.fr.md
@@ -9,8 +9,8 @@ scope: canada-baseline
 status: draft
 status_notice: false
 owner: docs-hardware
-last_reviewed: 2026-07-22
-review_by: 2026-10-17
+last_reviewed: 2026-09-02
+review_by: 2027-03-02
 difficulty: intermediate
 estimated_time: 10-15 minutes
 destructive: false
@@ -23,20 +23,16 @@ page_styles:
 
 # Choisir une antenne et une ligne d’alimentation
 
-Commencez par la radio, le connecteur et l’installation. Comparez ensuite les
-antennes qui couvrent la bande canadienne de 902–928 MHz.
+La plupart des appareils LoRa sont livrés avec une antenne d’usine très rudimentaire qui offre un rendement médiocre. La communauté du réseau maillé d’Ottawa a mis à l’essai de nombreuses antennes de remplacement, et celles ci-dessous sont fortement recommandées comme mises à niveau fiables pour la bande canadienne de 902–928 MHz.
 
 <div class="mc-guide-status" data-status="draft" markdown>
 
-**Vérifiez avant d’acheter.** Les produits ci-dessous sont des exemples à
-comparer, et non des recommandations de rendement vérifiées. Confirmez la fiche
-technique actuelle, le connecteur, les dimensions, les besoins de montage et la
-compatibilité avec la radio.
+**Vérifiez avant d’acheter.** Ces antennes ont bien fonctionné à Ottawa et dans d’autres réseaux, mais les révisions de produits changent. Confirmez auprès du fabricant la fiche technique actuelle, le connecteur, les dimensions, les besoins de montage et la compatibilité avec la radio avant de commander.
 
 </div>
 
 !!! danger "Coupez l’alimentation avant de changer une antenne"
-    N’alimentez pas une radio et ne transmettez pas sans que la bonne antenne soit branchée. Débranchez l’alimentation USB et la pile avant de brancher ou de retirer une antenne, puis suivez les instructions du fabricant de la radio.
+    Assurez-vous que l’appareil est débranché de l’alimentation et de la pile avant de changer d’antenne. Comme ces appareils peuvent émettre des signaux radio, allumer un appareil sans antenne peut l’endommager. [Plus d’information ici](https://electronics.stackexchange.com/questions/335912/can-i-break-a-radio-tranceiving-device-by-operating-it-with-no-antenna-connected){ target="_blank" rel="noopener" } (en anglais).
 
 ## Vérifier d’abord la compatibilité
 
@@ -49,47 +45,68 @@ compatibilité avec la radio.
   <li>La page du produit et la fiche technique actuelles confirment les renseignements utilisés pour votre choix.</li>
 </ul>
 
-## Antennes portatives à comparer
+## Antennes pour compagnons
 
-Avant de commander, confirmez si la radio utilise un connecteur SMA, RP-SMA ou
-interne.
+Ce sont des antennes SMA, plus compactes, qui ont pourtant constamment offert un excellent rendement à Ottawa et dans d’autres réseaux. Nous recommandons n’importe laquelle des options ci-dessous.
+
+!!! warning "SMA c. RP-SMA"
+    Portez une attention particulière au type de connecteur de votre compagnon ou répéteur, car certains sont livrés avec un connecteur SMA à polarité inversée (RP-SMA). Vous aurez besoin d’un adaptateur pour brancher une antenne SMA, ou d’acheter une antenne RP-SMA. [Plus d’information sur les différences entre ces connecteurs](https://blog.linitx.com/what-are-sma-rp-sma-connectors-and-whats-the-difference/){ target="_blank" rel="noopener" } (en anglais).
 
 <div class="mc-table-wrap" markdown>
 
-| Produit | Connecteur indiqué | À vérifier | Source |
+| Produit | Connecteur | Coût (CAD) | Lien |
 |---|---|---|---|
-| LINX ANT-916-CW-HW-SMA | SMA | Plage de fréquences, connecteur correspondant, dimensions et prise en charge de l’appareil | [DigiKey](https://www.digikey.ca/en/products/detail/te-connectivity-linx/ANT-916-CW-HW-SMA/2694126?s=N4IgTCBcDaIDIEkByANABAQSQFQLQE4BGANlwGEB1XACSoGUBZDEAXQF8g) |
-| Taoglas TI.09.A.0111 | SMA | Plage de fréquences, connecteur correspondant, dimensions et prise en charge de l’appareil | [DigiKey](https://www.digikey.ca/en/products/detail/taoglas-limited/TI-09-A-0111/2332695?s=N4IgTCBcDaICoEMD2BzANggzgAjgSQDoAGATgIEFiBGGkAXQF8g) |
-| Seeed Studio LoRa Antenna Kit | SMA | Plage de fréquences, contenu exact de la trousse, connecteur correspondant et prise en charge de l’appareil | [Seeed Studio](https://www.seeedstudio.com/LoRa-Antenna-Kit-for-reTerminal-DM-p-5714.html) |
+| Gizont 167CM 915MHz SMA M | SMA | 12 $ | [Space Hedgehog (boutique locale)](https://space-hedgehog.com/products/gizont-915mhz-antenna?variant=51602989711416) |
+| Gizont 167CM 915MHz SMA M | SMA | 10,53 $ | [AliExpress](https://www.aliexpress.com/item/1005004607615001.html) |
+| Gizont 167CM 915MHz RP-SMA M | RP-SMA | 10,53 $ | [AliExpress](https://www.aliexpress.com/item/1005004607615001.html) |
+| LINX ANT-916-CW-HW-SMA | SMA | 14,65 $ | [DigiKey](https://www.digikey.ca/en/products/detail/te-connectivity-linx/ANT-916-CW-HW-SMA/2694126?s=N4IgTCBcDaIDIEkByANABAQSQFQLQE4BGANlwGEB1XACSoGUBZDEAXQF8g) |
+| Taoglas TI.09.A.0111 | SMA | 17,47 $ | [DigiKey](https://www.digikey.ca/en/products/detail/taoglas-limited/TI-09-A-0111/2332695?s=N4IgTCBcDaICoEMD2BzANggzgAjgSQDoAGATgIEFiBGGkAXQF8g) |
+| Seeed Studio LoRa Antenna Kit | SMA | 6,79 $ | [Seeed Studio](https://www.seeedstudio.com/LoRa-Antenna-Kit-for-reTerminal-DM-p-5714.html) |
 
 </div>
 
-## Antennes fixes à comparer
+## Antennes omnidirectionnelles pour répéteurs
 
-Une antenne permanente de répéteur représente une décision d’installation
-complète, et non seulement un chiffre de gain. Tenez compte de la perte du
-câble, du nombre de connecteurs, du diagramme de rayonnement, des conditions RF
-locales, de la structure, de l’examen de la protection contre la foudre et de
-la mise à la terre, des intempéries et de l’accès sécuritaire.
+Ce sont des antennes de type N, les mieux adaptées aux répéteurs. Au strict minimum, tous les répéteurs devraient utiliser l’antenne Alfa. C’est une des grandes raisons du bon rendement du réseau d’Ottawa. MrAlders0n a établi une liaison de 110 km entre un répéteur et un compagnon avec une Alfa à chaque extrémité.
+
+Si vous voulez une antenne plus grande et plus performante, nous avons mis à l’essai l’antenne en fibre de verre Seeed de 1300 mm avec d’excellents résultats. Notez qu’elle mesure 1,3 mètre. Nous ne la recommandons que pour les répéteurs installés à une hauteur importante (environ 30 m au-dessus du sol ou plus) et destinés aux liaisons longue distance ou à la dorsale.
 
 <div class="mc-table-wrap" markdown>
 
-| Produit | Type | Connecteur indiqué | À vérifier | Source |
-|---|---|---|---|---|
-| Seeed Studio 318020693 | Omnidirectionnelle en fibre de verre | Type N | Plage de fréquences, diagramme, dimensions, charge au vent, montage et parcours du câble | [Mouser](https://www.mouser.ca/ProductDetail/Seeed-Studio/318020693?qs=By6Nw2ByBD0kjpJjgHd0aQ%3D%3D) |
-| L-com HG913Y-NF | Directionnelle | Type N | Plage de fréquences, diagramme, orientation, charge au vent, montage et parcours du câble | [DigiKey](https://www.digikey.ca/en/products/detail/l-com/HG913Y-NF/21289980) |
+| Produit | Connecteur | Coût (CAD) | Lien |
+|---|---|---|---|
+| Alfa AOA-915-5ACM | Type N | 34,99 $ | [Amazon](https://a.co/d/ieEIQpy) |
+| Seeed Studio RF Explorer 902-928MHz 8dBi, 1300 mm (318020693) | Type N | 110 $ | [Mouser](https://www.mouser.ca/ProductDetail/Seeed-Studio/318020693?qs=By6Nw2ByBD0kjpJjgHd0aQ%3D%3D) |
 
 </div>
 
-## Choisir la ligne d’alimentation
+## Antennes directionnelles pour répéteurs
 
-Utilisez le câble pratique le plus court dont la perte est acceptable.
-Confirmez les deux connecteurs, le type et la longueur du câble, sa perte à la
-fréquence d’utilisation, son indice pour l’extérieur, son rayon de courbure,
-son serre-câble et son étanchéité. [Infinite Cables](https://www.infinitecables.com/)
-est une source canadienne de câbles RF assemblés; son
-[exemple LMR-240 Ultra Flex de type N](https://www.infinitecables.com/products/lmr-240-ultra-flex-n-type-male-to-n-type-female-cable?variant=42809804980465)
-pourrait ne pas avoir les connecteurs dont vous avez besoin.
+Les antennes directionnelles sont destinées aux répéteurs fixes et aux liaisons longue distance point à point ou point à multipoint. Toutes les antennes ci-dessous utilisent un connecteur de type N et conviennent aux installations extérieures permanentes.
+
+<div class="mc-table-wrap" markdown>
+
+| Produit | Connecteur | Coût (CAD) | Lien |
+|---|---|---|---|
+| L-com HG913Y-NF | Type N | 237,17 $ | [DigiKey](https://www.digikey.ca/en/products/detail/l-com/HG913Y-NF/21289980) |
+
+</div>
+
+Une antenne permanente de répéteur représente une décision d’installation complète, et non seulement un chiffre de gain. Tenez compte de la perte du câble, du nombre de connecteurs, du diagramme de rayonnement, des conditions RF locales, de la structure, de la protection contre la foudre et de la mise à la terre, des intempéries et de l’accès sécuritaire.
+
+*Les prix ont été relevés au moment de la rédaction de cette liste (consultez la page liée pour le prix et la date à jour). Ils varient selon le fournisseur et peuvent exclure l’expédition.*
+
+## Câbles d’antenne
+
+Pour des câbles LMR-240 courts et de grande qualité, [Infinite Cables](https://www.infinitecables.com/), à Toronto, est la meilleure source que nous ayons trouvée. Leurs câbles sont plutôt chers, mais la qualité de fabrication est excellente et ils offrent une grande variété de longueurs et de combinaisons de connecteurs pour toute installation. Utilisez le câble pratique le plus court dont la perte est acceptable, et confirmez les deux connecteurs, le type et la longueur du câble, son indice pour l’extérieur, son rayon de courbure, son serre-câble et son étanchéité.
+
+<div class="mc-table-wrap" markdown>
+
+| Produit | Connecteur | Lien |
+|---|---|---|
+| LMR-240 Ultra Flex N-Type Male to N-Type Female | Type N mâle à type N femelle | [Infinite Cables](https://www.infinitecables.com/products/lmr-240-ultra-flex-n-type-male-to-n-type-female-cable?variant=42809804980465) |
+
+</div>
 
 ## Consigner le choix
 

--- a/docs/hardware/recommended-antenna.fr.md
+++ b/docs/hardware/recommended-antenna.fr.md
@@ -9,7 +9,7 @@ scope: canada-baseline
 status: draft
 status_notice: false
 owner: docs-hardware
-last_reviewed: 2026-09-02
+last_reviewed: 2026-09-03
 review_by: 2027-03-02
 difficulty: intermediate
 estimated_time: 10-15 minutes
@@ -23,7 +23,7 @@ page_styles:
 
 # Choisir une antenne et une ligne d’alimentation
 
-La plupart des appareils LoRa sont livrés avec une antenne d’usine très rudimentaire qui offre un rendement médiocre. La communauté du réseau maillé d’Ottawa a mis à l’essai de nombreuses antennes de remplacement, et celles ci-dessous sont fortement recommandées comme mises à niveau fiables pour la bande canadienne de 902–928 MHz.
+De nombreux appareils LoRa à antenne amovible sont livrés avec une antenne d’usine rudimentaire. La communauté d’Ottawa a obtenu de bons résultats avec les options de 902–928 MHz ci-dessous.
 
 <div class="mc-guide-status" data-status="draft" markdown>
 
@@ -67,7 +67,7 @@ Ce sont des antennes SMA, plus compactes, qui ont pourtant constamment offert un
 
 ## Antennes omnidirectionnelles pour répéteurs
 
-Ce sont des antennes de type N, les mieux adaptées aux répéteurs. Au strict minimum, tous les répéteurs devraient utiliser l’antenne Alfa. C’est une des grandes raisons du bon rendement du réseau d’Ottawa. MrAlders0n a établi une liaison de 110 km entre un répéteur et un compagnon avec une Alfa à chaque extrémité.
+Ces antennes de type N sont destinées aux répéteurs. L’Alfa est le choix de départ courant à Ottawa, mais la hauteur, la perte du câble, le terrain et les conditions RF locales influencent aussi la couverture.
 
 Si vous voulez une antenne plus grande et plus performante, nous avons mis à l’essai l’antenne en fibre de verre Seeed de 1300 mm avec d’excellents résultats. Notez qu’elle mesure 1,3 mètre. Nous ne la recommandons que pour les répéteurs installés à une hauteur importante (environ 30 m au-dessus du sol ou plus) et destinés aux liaisons longue distance ou à la dorsale.
 

--- a/docs/hardware/recommended-antenna.md
+++ b/docs/hardware/recommended-antenna.md
@@ -9,8 +9,8 @@ scope: canada-baseline
 status: draft
 status_notice: false
 owner: docs-hardware
-last_reviewed: 2026-07-22
-review_by: 2026-10-17
+last_reviewed: 2026-09-02
+review_by: 2027-03-02
 difficulty: intermediate
 estimated_time: 10-15 minutes
 destructive: false
@@ -23,16 +23,16 @@ page_styles:
 
 # Choose an antenna and feed line
 
-Start with the radio, connector, and installation. Then compare antennas that cover the Canadian 902–928 MHz band.
+Most LoRa devices ship with a very basic factory antenna that performs poorly. The Ottawa mesh community has tested many replacements, and the antennas below are highly recommended as reliable upgrades for the Canadian 902–928 MHz band.
 
 <div class="mc-guide-status" data-status="draft" markdown>
 
-**Check before buying.** The products below are examples to compare, not verified performance recommendations. Confirm the current datasheet, connector, dimensions, mounting needs, and radio compatibility.
+**Check before buying.** These antennas have worked well in Ottawa and other meshes, but product revisions change. Confirm the current datasheet, connector, dimensions, mounting needs, and radio compatibility with the manufacturer before ordering.
 
 </div>
 
 !!! danger "Disconnect power before changing an antenna"
-    Do not power or transmit from a radio without the correct antenna attached. Disconnect USB and battery power before connecting or removing an antenna, and follow the radio manufacturer's instructions.
+    Make sure your device is disconnected from power and battery when swapping an antenna. Since these devices can transmit radio signals, turning on a device without an antenna can damage it. [See more information here](https://electronics.stackexchange.com/questions/335912/can-i-break-a-radio-tranceiving-device-by-operating-it-with-no-antenna-connected){ target="_blank" rel="noopener" }.
 
 ## Check compatibility first
 
@@ -45,36 +45,68 @@ Start with the radio, connector, and installation. Then compare antennas that co
   <li>The current product page and datasheet support the details used in your decision.</li>
 </ul>
 
-## Portable antennas to compare
+## Companion antennas
 
-Confirm whether the radio uses SMA, RP-SMA, or an internal connector before ordering.
+These are SMA antennas and are more compact, yet they've consistently shown excellent performance in Ottawa and other meshes. We recommend any of the options listed here.
+
+!!! warning "SMA vs. RP-SMA"
+    Pay close attention to what connection type a companion or repeater has, since some come with Reverse Polarity SMA (RP-SMA). You will need an adapter to connect your SMA antenna, or you will need to buy an RP-SMA antenna. [More information on the differences between these connectors](https://blog.linitx.com/what-are-sma-rp-sma-connectors-and-whats-the-difference/){ target="_blank" rel="noopener" }.
 
 <div class="mc-table-wrap" markdown>
 
-| Product | Listed connector | Check | Source |
+| Product | Connector | Cost (CAD) | Link |
 |---|---|---|---|
-| LINX ANT-916-CW-HW-SMA | SMA | Frequency range, mating connector, dimensions, and device support | [DigiKey](https://www.digikey.ca/en/products/detail/te-connectivity-linx/ANT-916-CW-HW-SMA/2694126?s=N4IgTCBcDaIDIEkByANABAQSQFQLQE4BGANlwGEB1XACSoGUBZDEAXQF8g) |
-| Taoglas TI.09.A.0111 | SMA | Frequency range, mating connector, dimensions, and device support | [DigiKey](https://www.digikey.ca/en/products/detail/taoglas-limited/TI-09-A-0111/2332695?s=N4IgTCBcDaICoEMD2BzANggzgAjgSQDoAGATgIEFiBGGkAXQF8g) |
-| Seeed Studio LoRa Antenna Kit | SMA | Frequency range, exact kit contents, mating connector, and device support | [Seeed Studio](https://www.seeedstudio.com/LoRa-Antenna-Kit-for-reTerminal-DM-p-5714.html) |
+| Gizont 167CM 915MHz SMA M | SMA | $12 | [Space Hedgehog (local store)](https://space-hedgehog.com/products/gizont-915mhz-antenna?variant=51602989711416) |
+| Gizont 167CM 915MHz SMA M | SMA | $10.53 | [AliExpress](https://www.aliexpress.com/item/1005004607615001.html) |
+| Gizont 167CM 915MHz RP-SMA M | RP-SMA | $10.53 | [AliExpress](https://www.aliexpress.com/item/1005004607615001.html) |
+| LINX ANT-916-CW-HW-SMA | SMA | $14.65 | [DigiKey](https://www.digikey.ca/en/products/detail/te-connectivity-linx/ANT-916-CW-HW-SMA/2694126?s=N4IgTCBcDaIDIEkByANABAQSQFQLQE4BGANlwGEB1XACSoGUBZDEAXQF8g) |
+| Taoglas TI.09.A.0111 | SMA | $17.47 | [DigiKey](https://www.digikey.ca/en/products/detail/taoglas-limited/TI-09-A-0111/2332695?s=N4IgTCBcDaICoEMD2BzANggzgAjgSQDoAGATgIEFiBGGkAXQF8g) |
+| Seeed Studio LoRa Antenna Kit | SMA | $6.79 | [Seeed Studio](https://www.seeedstudio.com/LoRa-Antenna-Kit-for-reTerminal-DM-p-5714.html) |
 
 </div>
 
-## Fixed antennas to compare
+## Repeater omni antennas
 
-A permanent repeater antenna is a complete installation decision, not just a gain number. Include feed-line loss, connector count, pattern, local RF conditions, structure, lightning/grounding review, weather, and safe access.
+These are N-type antennas and are best suited for repeaters. At an absolute minimum, all repeaters should use the Alfa antenna. It is a major reason the Ottawa mesh performs as well as it does. MrAlders0n has made a link between a repeater and a companion at 110 km distance with an Alfa on both ends.
+
+If you want something larger and higher-performing, we have tested the Seeed 1300 mm fiberglass antenna with excellent results. Please note that it is 1.3 metres long. We only recommend this antenna for repeaters installed at significant height (around 30 m AGL or higher) and intended for long-distance links or backbone use.
 
 <div class="mc-table-wrap" markdown>
 
-| Product | Type | Listed connector | Check | Source |
-|---|---|---|---|---|
-| Seeed Studio 318020693 | Fiberglass omnidirectional | N-type | Frequency range, pattern, dimensions, wind load, mount, and cable path | [Mouser](https://www.mouser.ca/ProductDetail/Seeed-Studio/318020693?qs=By6Nw2ByBD0kjpJjgHd0aQ%3D%3D) |
-| L-com HG913Y-NF | Directional | N-type | Frequency range, pattern, aiming, wind load, mount, and cable path | [DigiKey](https://www.digikey.ca/en/products/detail/l-com/HG913Y-NF/21289980) |
+| Product | Connector | Cost (CAD) | Link |
+|---|---|---|---|
+| Alfa AOA-915-5ACM | N-type | $34.99 | [Amazon](https://a.co/d/ieEIQpy) |
+| Seeed Studio RF Explorer 902-928MHz 8dBi, 1300mm (318020693) | N-type | $110 | [Mouser](https://www.mouser.ca/ProductDetail/Seeed-Studio/318020693?qs=By6Nw2ByBD0kjpJjgHd0aQ%3D%3D) |
 
 </div>
 
-## Choose the feed line
+## Repeater directional antennas
 
-Use the shortest practical cable with acceptable loss. Confirm both connectors, cable type, length, loss at the operating frequency, outdoor rating, bend radius, strain relief, and weather sealing. [Infinite Cables](https://www.infinitecables.com/) is one Canadian source for assembled RF cables; its [LMR-240 Ultra Flex N-type example](https://www.infinitecables.com/products/lmr-240-ultra-flex-n-type-male-to-n-type-female-cable?variant=42809804980465) may not match your required connectors.
+Directional antennas are intended for fixed repeaters and long-distance point-to-point or point-to-multipoint links. All antennas listed here use N-type connectors and are suitable for permanent outdoor installations.
+
+<div class="mc-table-wrap" markdown>
+
+| Product | Connector | Cost (CAD) | Link |
+|---|---|---|---|
+| L-com HG913Y-NF | N-type | $237.17 | [DigiKey](https://www.digikey.ca/en/products/detail/l-com/HG913Y-NF/21289980) |
+
+</div>
+
+A permanent repeater antenna is a complete installation decision, not just a gain number. Include feed-line loss, connector count, pattern, local RF conditions, structure, lightning and grounding review, weather, and safe access.
+
+*Prices were recorded when this list was compiled (check the linked page for the current price and date). They will vary by supplier and may not include shipping.*
+
+## Antenna cables
+
+For short, high-quality LMR-240 cables, [Infinite Cables](https://www.infinitecables.com/) in Toronto is the best source we've found. Their cables are on the expensive side, but the build quality is excellent and they offer a wide variety of lengths and connector combinations to suit any installation. Use the shortest practical cable with acceptable loss, and confirm both connectors, cable type, length, outdoor rating, bend radius, strain relief, and weather sealing.
+
+<div class="mc-table-wrap" markdown>
+
+| Product | Connector | Link |
+|---|---|---|
+| LMR-240 Ultra Flex N-Type Male to N-Type Female | N-type M to N-type F | [Infinite Cables](https://www.infinitecables.com/products/lmr-240-ultra-flex-n-type-male-to-n-type-female-cable?variant=42809804980465) |
+
+</div>
 
 ## Record the decision
 

--- a/docs/hardware/recommended-antenna.md
+++ b/docs/hardware/recommended-antenna.md
@@ -9,7 +9,7 @@ scope: canada-baseline
 status: draft
 status_notice: false
 owner: docs-hardware
-last_reviewed: 2026-09-02
+last_reviewed: 2026-09-03
 review_by: 2027-03-02
 difficulty: intermediate
 estimated_time: 10-15 minutes
@@ -23,7 +23,7 @@ page_styles:
 
 # Choose an antenna and feed line
 
-Most LoRa devices ship with a very basic factory antenna that performs poorly. The Ottawa mesh community has tested many replacements, and the antennas below are highly recommended as reliable upgrades for the Canadian 902–928 MHz band.
+Many LoRa devices with removable antennas ship with a basic factory antenna. The Ottawa mesh community has had good results with the 902–928 MHz options below.
 
 <div class="mc-guide-status" data-status="draft" markdown>
 
@@ -67,7 +67,7 @@ These are SMA antennas and are more compact, yet they've consistently shown exce
 
 ## Repeater omni antennas
 
-These are N-type antennas and are best suited for repeaters. At an absolute minimum, all repeaters should use the Alfa antenna. It is a major reason the Ottawa mesh performs as well as it does. MrAlders0n has made a link between a repeater and a companion at 110 km distance with an Alfa on both ends.
+These N-type antennas are intended for repeaters. The Alfa is Ottawa's common starting point, but antenna height, feed-line loss, terrain, and local RF conditions also affect coverage.
 
 If you want something larger and higher-performing, we have tested the Seeed 1300 mm fiberglass antenna with excellent results. Please note that it is 1.3 metres long. We only recommend this antenna for repeaters installed at significant height (around 30 m AGL or higher) and intended for long-distance links or backbone use.
 

--- a/docs/hardware/recommended-companions.fr.md
+++ b/docs/hardware/recommended-companions.fr.md
@@ -9,7 +9,7 @@ scope: canada-baseline
 status: draft
 status_notice: false
 owner: docs-hardware
-last_reviewed: 2026-09-02
+last_reviewed: 2026-09-03
 review_by: 2027-03-02
 difficulty: beginner
 estimated_time: 10-15 minutes
@@ -26,12 +26,12 @@ Il existe aussi des compagnons autonomes avec écran et commandes intégrés. Il
 
 <div class="mc-guide-status" data-status="draft" markdown>
 
-**Vérifiez avant d’acheter.** Ces appareils ont été essayés et éprouvés par la communauté d’Ottawa et d’autres réseaux, mais les révisions de produits et la prise en charge du micrologiciel changent. Confirmez le modèle exact, la bande radio canadienne, la cible de micrologiciel du compagnon, le connecteur et les accessoires inclus dans le [programme officiel de mise à jour MeshCore](https://meshcore.io/flasher) et dans l’information à jour du fabricant.
+**Vérifiez avant d’acheter.** Ces appareils ont été essayés et éprouvés par la communauté d’Ottawa et d’autres réseaux, mais les révisions de produits et la prise en charge du micrologiciel changent. Confirmez le modèle exact, la bande radio canadienne, la cible de micrologiciel du compagnon, le connecteur et les accessoires inclus dans le [programme officiel de mise à jour MeshCore](https://flasher.meshcore.io/) et dans l’information à jour du fabricant.
 
 </div>
 
-!!! warning "Remplacez l’antenne du compagnon"
-    L’antenne incluse offre un rendement médiocre sur tous ces modèles. Prévoyez la remplacer, au minimum par une Gizont, sur les compagnons qui permettent de changer d’antenne.
+!!! warning "Remplacez seulement une antenne amovible"
+    Les compagnons à antenne amovible peuvent profiter d’une des antennes testées ci-dessous. N’ouvrez pas et ne modifiez pas un appareil scellé à antenne interne, comme le T1000-E ou le WisMesh Tag.
 
     Voir : [Antennes recommandées](recommended-antenna.md)
 
@@ -60,9 +60,9 @@ Les compagnons préassemblés suivants sont populaires et largement offerts :
 | Produit | Notes | Lien |
 |---|---|---|
 | **ThinkNode M1** | Appareil compact basé sur le nRF52840, avec écran de 1,54 po et GPS. Conçu comme compagnon prêt à l’emploi pour une messagerie et un suivi fiables. **Note :** connecteur RP-SMA. Voir l’avertissement SMA c. RP-SMA ci-dessus. | [Elecrow](https://www.elecrow.com/thinknode-m1-meshtastic-lora-signal-transceiver-powered-by-nrf52840-with-154-screen-support-gps.html) |
-| **LilyGO T-Echo** | Appareil compact avec écran et GPS intégrés. Une option solide, prête à l’emploi, qui exige peu de configuration. **Note :** achetez la version sans micrologiciel préinstallé; elle est moins chère et facile à programmer avec le programme de mise à jour Web. | [Boutique LilyGO](https://lilygo.cc/products/t-echo-lilygo) |
+| **LilyGO T-Echo** | Appareil compact avec écran et GPS intégrés. Choisissez la version 915 MHz pour le Canada, puis installez le micrologiciel compagnon MeshCore actuel. | [Boutique LilyGO](https://lilygo.cc/products/t-echo-lilygo) |
 | **SenseCAP T1000-E** | Traceur mince en format carte de Seeed Studio. Portatif et certifié IP65. **Note :** portée plus limitée en raison des antennes internes. | [Seeed Studio](https://www.seeedstudio.com/SenseCAP-Card-Tracker-T1000-E-for-Meshtastic-p-5913.html) |
-| **RAK WisMesh Tag** | Appareil robuste avec GPS, antennes intégrées, pile de 1000 mAh et boîtier IP66. Micrologiciel préinstallé pour une utilisation immédiate. **Note :** portée plus limitée en raison des antennes internes. | [AliExpress](https://www.aliexpress.com/item/1005009754254701.html) |
+| **RAK WisMesh Tag** | Appareil robuste avec GPS, antennes intégrées, pile de 1000 mAh et boîtier IP66. Il est livré avec Meshtastic; installez le micrologiciel compagnon MeshCore actuel avant de l’utiliser. **Note :** portée plus limitée en raison des antennes internes. | [RAKwireless](https://store.rakwireless.com/products/wismesh-tag-meshtastic-gps-lora-tracker-ip66) |
 
 </div>
 
@@ -87,7 +87,7 @@ Il s’agit d’un rôle de **compagnon** et il exige un téléphone intelligent
 
 *Coût total approximatif :* **95,68 $ CAD**
 
-*Les prix ont été relevés au moment de la rédaction de cette liste (consultez la page liée pour le prix et la date à jour). Ils varient et peuvent inclure les frais d’expédition; confirmez-les à partir des liens. Les piles MakerFocus sont expédiées de Chine sans droits de douane.*
+*Les prix ont été relevés au moment de la rédaction. Consultez les pages liées pour vérifier les prix, l’expédition, les droits de douane et la disponibilité.*
 
 !!! warning "Boîtier pour l’exemple de montage"
     Cet exemple de montage ne comprend pas de boîtier. Pour des boîtiers à imprimer en 3D, consultez les **[modèles d’Alley Cat](https://www.printables.com/@AlleyCat/models)**. Ils conviennent très bien aux compagnons faits maison. Assurez-vous que le boîtier choisi peut recevoir la pile de 3000 mAh et le connecteur IPEX à SMA à angle droit.
@@ -105,7 +105,7 @@ Il existe des appareils autonomes comme le **T-Deck**, mais nous recommandons de
 | Produit | Notes | Lien |
 |---|---|---|
 | **LilyGO T-LORA Pager** | Appareil de messagerie LoRa autonome et compact, au style d’un téléavertisseur classique. Utile pour des communications hors réseau simples, sans téléphone intelligent. | [Boutique LilyGO](https://lilygo.cc/en-ca/products/t-lora-pager) |
-| **LilyGO T-Deck Plus** | Version mise à jour du T-Deck, avec de meilleures caractéristiques et des raffinements. Conçu en pensant à MeshCore. **Toutefois :** la boule de commande intégrée est un inconvénient majeur que beaucoup d’utilisateurs n’aiment pas. | [Boutique LilyGO](https://lilygo.cc/products/t-deck-plus-meshtastic) |
+| **LilyGO T-Deck Plus** | Appareil autonome pris en charge par le micrologiciel Ripple de MeshCore. La boule de commande peut être moins pratique; tenez compte des commandes avant de choisir cet appareil. | [Boutique LilyGO](https://lilygo.cc/products/t-deck-plus-meshtastic) |
 
 </div>
 

--- a/docs/hardware/recommended-companions.fr.md
+++ b/docs/hardware/recommended-companions.fr.md
@@ -87,7 +87,7 @@ Il s’agit d’un rôle de **compagnon** et il exige un téléphone intelligent
 
 *Coût total approximatif :* **95,68 $ CAD**
 
-*Les prix ont été relevés au moment de la rédaction. Consultez les pages liées pour vérifier les prix, l’expédition, les droits de douane et la disponibilité.*
+*Les prix datent du 2 septembre 2026. Consultez les pages liées pour vérifier les prix, l’expédition, les droits de douane et la disponibilité.*
 
 !!! warning "Boîtier pour l’exemple de montage"
     Cet exemple de montage ne comprend pas de boîtier. Pour des boîtiers à imprimer en 3D, consultez les **[modèles d’Alley Cat](https://www.printables.com/@AlleyCat/models)**. Ils conviennent très bien aux compagnons faits maison. Assurez-vous que le boîtier choisi peut recevoir la pile de 3000 mAh et le connecteur IPEX à SMA à angle droit.

--- a/docs/hardware/recommended-companions.fr.md
+++ b/docs/hardware/recommended-companions.fr.md
@@ -9,8 +9,8 @@ scope: canada-baseline
 status: draft
 status_notice: false
 owner: docs-hardware
-last_reviewed: 2026-07-22
-review_by: 2026-10-17
+last_reviewed: 2026-09-02
+review_by: 2027-03-02
 difficulty: beginner
 estimated_time: 10-15 minutes
 destructive: false
@@ -20,56 +20,94 @@ page_styles:
 
 # Choisir un appareil compagnon
 
-Un compagnon est votre appareil personnel de messagerie MeshCore. Choisissez
-si vous préférez utiliser un téléphone ou des commandes intégrées, puis
-confirmez le modèle exact dans le
-[programme officiel de mise à jour MeshCore](https://meshcore.io/flasher).
+Les appareils compagnons utilisent un micrologiciel de compagnon dédié et servent de points d’accès utilisateur sur le réseau MeshCore. La plupart se jumellent à votre téléphone intelligent par Bluetooth Low Energy (BLE) pour donner accès au réseau maillé.
+
+Il existe aussi des compagnons autonomes avec écran et commandes intégrés. Ils fonctionnent sans téléphone, mais restent des points d’accès.
 
 <div class="mc-guide-status" data-status="draft" markdown>
 
-**Vérifiez avant d’acheter.** Ces appareils sont proposés à titre de comparaison
-et ne forment pas une liste de compatibilité garantie. Confirmez le modèle
-exact, la bande radio canadienne, la cible de micrologiciel du compagnon, le
-connecteur et les accessoires inclus.
+**Vérifiez avant d’acheter.** Ces appareils ont été essayés et éprouvés par la communauté d’Ottawa et d’autres réseaux, mais les révisions de produits et la prise en charge du micrologiciel changent. Confirmez le modèle exact, la bande radio canadienne, la cible de micrologiciel du compagnon, le connecteur et les accessoires inclus dans le [programme officiel de mise à jour MeshCore](https://meshcore.io/flasher) et dans l’information à jour du fabricant.
 
 </div>
 
-## Choisir comment vous voulez l’utiliser
+!!! warning "Remplacez l’antenne du compagnon"
+    L’antenne incluse offre un rendement médiocre sur tous ces modèles. Prévoyez la remplacer, au minimum par une Gizont, sur les compagnons qui permettent de changer d’antenne.
 
-<div class="mc-decision-grid">
-  <section class="mc-decision-card">
-    <h3>Jumelé à un téléphone</h3>
-    <p>Votre téléphone fournit l’interface principale et se connecte à la radio par Bluetooth Low Energy (BLE).</p>
-    <p><strong>À vérifier :</strong> la compatibilité du téléphone, la pile, l’antenne et la cible exacte du compagnon.</p>
-  </section>
-  <section class="mc-decision-card">
-    <h3>Autonome</h3>
-    <p>Un écran et des commandes intégrées permettent l’utilisation normale de la messagerie sans téléphone.</p>
-    <p><strong>À vérifier :</strong> si le micrologiciel actuel prend en charge le modèle et toutes les commandes dont vous avez besoin.</p>
-  </section>
-  <section class="mc-decision-card">
-    <h3>À construire soi-même</h3>
-    <p>Vous choisissez la carte, la pile, le boîtier, le câble et l’antenne.</p>
-    <p><strong>À vérifier :</strong> la révision de la carte, la polarité et la protection de la pile, l’ajustement du boîtier et chaque connecteur d’antenne.</p>
-  </section>
-</div>
+    Voir : [Antennes recommandées](recommended-antenna.md)
 
-## Appareils à comparer
+## Compagnons Bluetooth Low Energy (BLE)
+
+Ces appareils exigent un téléphone intelligent et l’application MeshCore. Ils se connectent à votre téléphone par BLE, et vous utilisez l’application pour interagir avec le réseau maillé. Dans cette configuration, le compagnon sert uniquement de radio et relie votre téléphone au réseau.
+
+### Préassemblés
+
+La façon la plus simple de commencer est d’acheter un compagnon, d’y installer MeshCore et de rejoindre le réseau. L’application MeshCore se connecte à l’appareil par BLE et sert à envoyer et à recevoir des messages sur le réseau maillé.
+
+!!! warning "Note importante sur le ThinkNode M1"
+    Assurez-vous de commander une **antenne RP-SMA** avec l’appareil.
+
+    **N’achetez pas une antenne SMA par erreur. Il vous faut précisément une RP-SMA.**
+
+    ThinkNode utilise un connecteur RP-SMA sur le ThinkNode M1.
+
+!!! warning "Ensembles AliExpress"
+    AliExpress affiche habituellement l’article le moins cher (par exemple, seulement le module GPS) à l’ouverture d’un lien. Assurez-vous de choisir le bon ensemble avant de l’ajouter à votre panier.
+
+Les compagnons préassemblés suivants sont populaires et largement offerts :
 
 <div class="mc-table-wrap" markdown>
 
-| Appareil | Style | À vérifier avant l’achat | Fabricant |
-|---|---|---|---|
-| ThinkNode M1 | Jumelé à un téléphone, avec écran | Cible exacte du programme de mise à jour, modèle de 902–928 MHz, connecteur d’antenne, pile et accessoires inclus | [Elecrow](https://www.elecrow.com/thinknode-m1-meshtastic-lora-signal-transceiver-powered-by-nrf52840-with-154-screen-support-gps.html) |
-| LilyGO T-Echo | Jumelé à un téléphone, avec écran | Révision exacte du matériel, cible du programme de mise à jour, bande radio, connecteur et antenne incluse | [LilyGO](https://lilygo.cc/products/t-echo-lilygo) |
-| SenseCAP T1000-E | Jumelé à un téléphone, boîtier en forme de carte | Cible exacte du programme de mise à jour, bande radio, limites de l’antenne interne et prise en charge du téléphone | [Seeed Studio](https://www.seeedstudio.com/SenseCAP-Card-Tracker-T1000-E-for-Meshtastic-p-5913.html) |
-| LilyGO T-LORA Pager | Commandes autonomes | Révision exacte du matériel et prise en charge actuelle de l’écran, du clavier et de l’utilisation prévue | [LilyGO](https://lilygo.cc/en-ca/products/t-lora-pager) |
-| LilyGO T-Deck Plus | Commandes autonomes | Révision exacte du matériel et prise en charge actuelle de l’écran, du clavier, de la boule de commande et de l’utilisation prévue | [LilyGO](https://lilygo.cc/products/t-deck-plus-meshtastic) |
+| Produit | Notes | Lien |
+|---|---|---|
+| **ThinkNode M1** | Appareil compact basé sur le nRF52840, avec écran de 1,54 po et GPS. Conçu comme compagnon prêt à l’emploi pour une messagerie et un suivi fiables. **Note :** connecteur RP-SMA. Voir l’avertissement SMA c. RP-SMA ci-dessus. | [Elecrow](https://www.elecrow.com/thinknode-m1-meshtastic-lora-signal-transceiver-powered-by-nrf52840-with-154-screen-support-gps.html) |
+| **LilyGO T-Echo** | Appareil compact avec écran et GPS intégrés. Une option solide, prête à l’emploi, qui exige peu de configuration. **Note :** achetez la version sans micrologiciel préinstallé; elle est moins chère et facile à programmer avec le programme de mise à jour Web. | [Boutique LilyGO](https://lilygo.cc/products/t-echo-lilygo) |
+| **SenseCAP T1000-E** | Traceur mince en format carte de Seeed Studio. Portatif et certifié IP65. **Note :** portée plus limitée en raison des antennes internes. | [Seeed Studio](https://www.seeedstudio.com/SenseCAP-Card-Tracker-T1000-E-for-Meshtastic-p-5913.html) |
+| **RAK WisMesh Tag** | Appareil robuste avec GPS, antennes intégrées, pile de 1000 mAh et boîtier IP66. Micrologiciel préinstallé pour une utilisation immédiate. **Note :** portée plus limitée en raison des antennes internes. | [AliExpress](https://www.aliexpress.com/item/1005009754254701.html) |
 
 </div>
 
-!!! note "Les offres changent"
-    Une page de produit peut sélectionner par défaut une autre bande radio, une autre trousse d’accessoires ou un autre connecteur. Vérifiez l’option choisie avant de passer à la caisse.
+### À construire soi-même
+
+Pour les bricoleurs qui aiment se procurer les pièces et assembler leur propre appareil, voici un exemple de montage adapté à Ottawa. Consultez les [antennes recommandées](recommended-antenna.md) pour d’autres options d’antenne.
+
+Il s’agit d’un rôle de **compagnon** et il exige un téléphone intelligent. L’application MeshCore se connecte à l’appareil par BLE et sert à envoyer et à recevoir des messages sur le réseau maillé.
+
+#### Exemple de montage maison
+
+<div class="mc-table-wrap" markdown>
+
+| Article | Nom du produit | Coût (CAD) | Lien |
+|---|---|---|---|
+| **Carte LoRa** | Heltec T114 (ensemble avec écran) | 45,99 $ | [AliExpress](https://www.aliexpress.com/item/1005007916299029.html) |
+| **Câble IPEX à SMA à angle droit** | SMA-KW 2PCS 8cm | 4,67 $ | [AliExpress](https://www.aliexpress.com/item/1005009270132403.html) |
+| **Pile** | MakerFocus LiPo 3,7 V 3000 mAh (paquet de 4), connecteur Micro JST 1.5 avec circuit de protection | 34,34 $ | [MakerFocus](https://www.makerfocus.com/products/makerfocus-3-7v-3000mah-lithium-rechargeable-battery-1s-3c-lipo-battery-pack-of-4?variant=44823607541998) |
+| **Antenne** | Gizont 167CM 915MHz SMA M | 10,68 $ | [AliExpress](https://www.aliexpress.com/item/1005004607615001.html) (assurez-vous de choisir la bonne antenne à l’ouverture du lien) |
+
+</div>
+
+*Coût total approximatif :* **95,68 $ CAD**
+
+*Les prix ont été relevés au moment de la rédaction de cette liste (consultez la page liée pour le prix et la date à jour). Ils varient et peuvent inclure les frais d’expédition; confirmez-les à partir des liens. Les piles MakerFocus sont expédiées de Chine sans droits de douane.*
+
+!!! warning "Boîtier pour l’exemple de montage"
+    Cet exemple de montage ne comprend pas de boîtier. Pour des boîtiers à imprimer en 3D, consultez les **[modèles d’Alley Cat](https://www.printables.com/@AlleyCat/models)**. Ils conviennent très bien aux compagnons faits maison. Assurez-vous que le boîtier choisi peut recevoir la pile de 3000 mAh et le connecteur IPEX à SMA à angle droit.
+
+Si vous êtes dans la région d’Ottawa, vous pouvez aussi acheter ce montage entièrement assemblé auprès de [Space Hedgehog](https://space-hedgehog.com/).
+
+## Appareils autonomes
+
+Il existe des appareils autonomes comme le **T-Deck**, mais nous recommandons de commencer par un compagnon jumelé à un téléphone. Les appareils autonomes sont généralement plus chers, leur interface est moins fluide que l’application mobile, et ils présentent encore des particularités et des limites de micrologiciel qui peuvent compliquer la tâche des débutants.
+
+### Appareils autonomes offerts
+
+<div class="mc-table-wrap" markdown>
+
+| Produit | Notes | Lien |
+|---|---|---|
+| **LilyGO T-LORA Pager** | Appareil de messagerie LoRa autonome et compact, au style d’un téléavertisseur classique. Utile pour des communications hors réseau simples, sans téléphone intelligent. | [Boutique LilyGO](https://lilygo.cc/en-ca/products/t-lora-pager) |
+| **LilyGO T-Deck Plus** | Version mise à jour du T-Deck, avec de meilleures caractéristiques et des raffinements. Conçu en pensant à MeshCore. **Toutefois :** la boule de commande intégrée est un inconvénient majeur que beaucoup d’utilisateurs n’aiment pas. | [Boutique LilyGO](https://lilygo.cc/products/t-deck-plus-meshtastic) |
+
+</div>
 
 ## Avant d’acheter
 

--- a/docs/hardware/recommended-companions.md
+++ b/docs/hardware/recommended-companions.md
@@ -87,7 +87,7 @@ This is a **companion node** role and requires a smartphone. The MeshCore app co
 
 *Approximate total cost:* **$95.68 CAD**
 
-*Prices were recorded when this list was compiled. Check the linked pages for current prices, shipping, duties, and availability.*
+*Prices are dated September 2, 2026. Check the linked pages for current prices, shipping, duties, and availability.*
 
 !!! warning "Case for the example DIY build"
     This DIY build example does not include a case. For 3D-printable cases, check out **[Alley Cat's models](https://www.printables.com/@AlleyCat/models)**. They are excellent for custom companion node builds. Make sure the case you choose will fit the 3000 mAh battery and the right-angle IPEX to SMA connector.

--- a/docs/hardware/recommended-companions.md
+++ b/docs/hardware/recommended-companions.md
@@ -9,7 +9,7 @@ scope: canada-baseline
 status: draft
 status_notice: false
 owner: docs-hardware
-last_reviewed: 2026-09-02
+last_reviewed: 2026-09-03
 review_by: 2027-03-02
 difficulty: beginner
 estimated_time: 10-15 minutes
@@ -26,12 +26,12 @@ There are also standalone companion nodes with built-in screens and input device
 
 <div class="mc-guide-status" data-status="draft" markdown>
 
-**Check before buying.** These devices have been tried and tested by the Ottawa community and other meshes, but product revisions and firmware support change. Confirm the exact model, Canadian radio band, companion firmware target, connector, and included accessories in the [official MeshCore flasher](https://meshcore.io/flasher) and in current manufacturer information.
+**Check before buying.** These devices have been tried and tested by the Ottawa community and other meshes, but product revisions and firmware support change. Confirm the exact model, Canadian radio band, companion firmware target, connector, and included accessories in the [official MeshCore flasher](https://flasher.meshcore.io/) and in current manufacturer information.
 
 </div>
 
-!!! warning "Upgrade the companion antenna"
-    The included antenna performs poorly on all of these models. Plan to replace it, and upgrade to at least the Gizont on companions that support changing the antenna.
+!!! warning "Only replace removable antennas"
+    Companions with removable antennas may benefit from one of the tested upgrades below. Do not open or modify a sealed, internal-antenna device such as the T1000-E or WisMesh Tag.
 
     See: [Recommended antennas](recommended-antenna.md)
 
@@ -60,9 +60,9 @@ The following pre-built companion nodes are popular and widely available:
 | Product | Notes | Link |
 |---|---|---|
 | **ThinkNode M1** | Compact device powered by the nRF52840 with a 1.54" screen and GPS support. Designed as a ready-to-use companion node for reliable messaging and tracking. **Note:** Has an RP-SMA connector. See the SMA vs. RP-SMA warning above. | [Elecrow](https://www.elecrow.com/thinknode-m1-meshtastic-lora-signal-transceiver-powered-by-nrf52840-with-154-screen-support-gps.html) |
-| **LilyGO T-Echo** | Compact device with onboard display and GPS. A solid ready-to-use option with minimal setup required. **Note:** Buy the non-flashed version; it's cheaper and easy to flash with the web flasher. | [LilyGO Store](https://lilygo.cc/products/t-echo-lilygo) |
+| **LilyGO T-Echo** | Compact device with onboard display and GPS. Choose the 915 MHz version for Canada, then flash the current MeshCore companion firmware. | [LilyGO Store](https://lilygo.cc/products/t-echo-lilygo) |
 | **SenseCAP T1000-E** | Slim card-style tracker device from Seeed Studio. Portable and IP65-rated. **Note:** Range is more limited due to internal antennas. | [Seeed Studio](https://www.seeedstudio.com/SenseCAP-Card-Tracker-T1000-E-for-Meshtastic-p-5913.html) |
-| **RAK WisMesh Tag** | Rugged device with GPS, integrated antennas, 1000 mAh battery, and IP66 enclosure. Pre-flashed firmware for instant use. **Note:** Range is more limited due to internal antennas. | [AliExpress](https://www.aliexpress.com/item/1005009754254701.html) |
+| **RAK WisMesh Tag** | Rugged device with GPS, integrated antennas, 1000 mAh battery, and IP66 enclosure. It ships with Meshtastic, so flash the current MeshCore companion firmware before use. **Note:** Range is more limited due to internal antennas. | [RAKwireless](https://store.rakwireless.com/products/wismesh-tag-meshtastic-gps-lora-tracker-ip66) |
 
 </div>
 
@@ -87,7 +87,7 @@ This is a **companion node** role and requires a smartphone. The MeshCore app co
 
 *Approximate total cost:* **$95.68 CAD**
 
-*Prices were recorded when this list was compiled (check the linked page for the current price and date). They will vary and may include shipping costs, so confirm with the links. MakerFocus batteries are shipped from China with no duties.*
+*Prices were recorded when this list was compiled. Check the linked pages for current prices, shipping, duties, and availability.*
 
 !!! warning "Case for the example DIY build"
     This DIY build example does not include a case. For 3D-printable cases, check out **[Alley Cat's models](https://www.printables.com/@AlleyCat/models)**. They are excellent for custom companion node builds. Make sure the case you choose will fit the 3000 mAh battery and the right-angle IPEX to SMA connector.
@@ -105,7 +105,7 @@ There are standalone devices such as the **T-Deck**, but we recommend starting w
 | Product | Notes | Link |
 |---|---|---|
 | **LilyGO T-LORA Pager** | A compact standalone LoRa messaging device styled like a classic pager. Useful for simple off-grid communication without needing a smartphone. | [LilyGO Store](https://lilygo.cc/en-ca/products/t-lora-pager) |
-| **LilyGO T-Deck Plus** | Updated version of the T-Deck with improved specs and refinements. Built with MeshCore in mind. **However:** the built-in trackball is a major downside and many users dislike it. | [LilyGO Store](https://lilygo.cc/products/t-deck-plus-meshtastic) |
+| **LilyGO T-Deck Plus** | Standalone device supported by MeshCore's Ripple firmware. The trackball can be awkward, so consider the controls before choosing it. | [LilyGO Store](https://lilygo.cc/products/t-deck-plus-meshtastic) |
 
 </div>
 

--- a/docs/hardware/recommended-companions.md
+++ b/docs/hardware/recommended-companions.md
@@ -9,8 +9,8 @@ scope: canada-baseline
 status: draft
 status_notice: false
 owner: docs-hardware
-last_reviewed: 2026-07-22
-review_by: 2026-10-17
+last_reviewed: 2026-09-02
+review_by: 2027-03-02
 difficulty: beginner
 estimated_time: 10-15 minutes
 destructive: false
@@ -20,50 +20,94 @@ page_styles:
 
 # Choose a companion device
 
-A companion is your personal MeshCore messaging device. Choose whether you want to use a phone or built-in controls, then confirm the exact model in the [official MeshCore flasher](https://meshcore.io/flasher).
+Companion nodes run dedicated companion firmware and operate as user endpoints on the MeshCore network. Most companion nodes pair with your smartphone over Bluetooth Low Energy (BLE) to provide access to the mesh.
+
+There are also standalone companion nodes with built-in screens and input devices. These operate without a smartphone but still function as endpoints.
 
 <div class="mc-guide-status" data-status="draft" markdown>
 
-**Check before buying.** These are devices to compare, not a guaranteed compatibility list. Confirm the exact model, Canadian radio band, companion firmware target, connector, and included accessories.
+**Check before buying.** These devices have been tried and tested by the Ottawa community and other meshes, but product revisions and firmware support change. Confirm the exact model, Canadian radio band, companion firmware target, connector, and included accessories in the [official MeshCore flasher](https://meshcore.io/flasher) and in current manufacturer information.
 
 </div>
 
-## Choose how you want to use it
+!!! warning "Upgrade the companion antenna"
+    The included antenna performs poorly on all of these models. Plan to replace it, and upgrade to at least the Gizont on companions that support changing the antenna.
 
-<div class="mc-decision-grid">
-  <section class="mc-decision-card">
-    <h3>Phone-paired</h3>
-    <p>Your phone provides the main interface and connects to the radio over Bluetooth Low Energy (BLE).</p>
-    <p><strong>Check:</strong> phone compatibility, battery, antenna, and the exact companion target.</p>
-  </section>
-  <section class="mc-decision-card">
-    <h3>Standalone</h3>
-    <p>A display and built-in controls allow normal messaging without a phone.</p>
-    <p><strong>Check:</strong> whether current firmware supports the model and all controls you need.</p>
-  </section>
-  <section class="mc-decision-card">
-    <h3>Build your own</h3>
-    <p>You choose the board, battery, enclosure, cable, and antenna.</p>
-    <p><strong>Check:</strong> board revision, battery polarity and protection, enclosure fit, and every antenna connector.</p>
-  </section>
-</div>
+    See: [Recommended antennas](recommended-antenna.md)
 
-## Devices to compare
+## Bluetooth Low Energy (BLE) companions
+
+These devices require a smartphone and the MeshCore app. They connect to your phone over BLE, and you use the app to interact with the mesh. In this setup, the companion acts only as the radio, linking your phone to the mesh network.
+
+### Pre-built
+
+The easiest way to get started is to buy a companion node, flash it with MeshCore, and join the mesh. The MeshCore app connects to the node over BLE and is used to send and receive messages on the mesh.
+
+!!! warning "Important ThinkNode M1 note"
+    Make sure to order an **RP-SMA antenna** with the device.
+
+    **Do not accidentally buy SMA. You specifically need RP-SMA.**
+
+    ThinkNode uses RP-SMA on the ThinkNode M1.
+
+!!! warning "AliExpress bundles"
+    AliExpress usually shows the cheapest item (for example, only the GPS module) when opening a link. Make sure you select the right bundle when adding to your cart.
+
+The following pre-built companion nodes are popular and widely available:
 
 <div class="mc-table-wrap" markdown>
 
-| Device | Style | Check before buying | Manufacturer |
-|---|---|---|---|
-| ThinkNode M1 | Phone-paired, display | Exact flasher target, 902–928 MHz model, antenna connector, included battery and accessories | [Elecrow](https://www.elecrow.com/thinknode-m1-meshtastic-lora-signal-transceiver-powered-by-nrf52840-with-154-screen-support-gps.html) |
-| LilyGO T-Echo | Phone-paired, display | Exact hardware revision, flasher target, radio band, connector, and included antenna | [LilyGO](https://lilygo.cc/products/t-echo-lilygo) |
-| SenseCAP T1000-E | Phone-paired, card-style enclosure | Exact flasher target, radio band, internal-antenna limitations, and phone support | [Seeed Studio](https://www.seeedstudio.com/SenseCAP-Card-Tracker-T1000-E-for-Meshtastic-p-5913.html) |
-| LilyGO T-LORA Pager | Standalone controls | Exact hardware revision and current support for the display, keyboard, and intended workflow | [LilyGO](https://lilygo.cc/en-ca/products/t-lora-pager) |
-| LilyGO T-Deck Plus | Standalone controls | Exact hardware revision and current support for the display, keyboard, trackball, and intended workflow | [LilyGO](https://lilygo.cc/products/t-deck-plus-meshtastic) |
+| Product | Notes | Link |
+|---|---|---|
+| **ThinkNode M1** | Compact device powered by the nRF52840 with a 1.54" screen and GPS support. Designed as a ready-to-use companion node for reliable messaging and tracking. **Note:** Has an RP-SMA connector. See the SMA vs. RP-SMA warning above. | [Elecrow](https://www.elecrow.com/thinknode-m1-meshtastic-lora-signal-transceiver-powered-by-nrf52840-with-154-screen-support-gps.html) |
+| **LilyGO T-Echo** | Compact device with onboard display and GPS. A solid ready-to-use option with minimal setup required. **Note:** Buy the non-flashed version; it's cheaper and easy to flash with the web flasher. | [LilyGO Store](https://lilygo.cc/products/t-echo-lilygo) |
+| **SenseCAP T1000-E** | Slim card-style tracker device from Seeed Studio. Portable and IP65-rated. **Note:** Range is more limited due to internal antennas. | [Seeed Studio](https://www.seeedstudio.com/SenseCAP-Card-Tracker-T1000-E-for-Meshtastic-p-5913.html) |
+| **RAK WisMesh Tag** | Rugged device with GPS, integrated antennas, 1000 mAh battery, and IP66 enclosure. Pre-flashed firmware for instant use. **Note:** Range is more limited due to internal antennas. | [AliExpress](https://www.aliexpress.com/item/1005009754254701.html) |
 
 </div>
 
-!!! note "Listings change"
-    A product page can default to another radio band, accessory bundle, or connector. Check the selected option before checkout.
+### Build your own
+
+For hobbyists who like to source parts and assemble their own node, here is an Ottawa-friendly example build. See [Recommended antennas](recommended-antenna.md) for other antenna options.
+
+This is a **companion node** role and requires a smartphone. The MeshCore app connects to the node over BLE and is used to send and receive messages on the mesh.
+
+#### Example DIY build
+
+<div class="mc-table-wrap" markdown>
+
+| Item | Product name | Cost (CAD) | Link |
+|---|---|---|---|
+| **LoRa board** | Heltec T114 (bundle with screen) | $45.99 | [AliExpress](https://www.aliexpress.com/item/1005007916299029.html) |
+| **Right-angle IPEX to SMA pigtail cable** | SMA-KW 2PCS 8cm | $4.67 | [AliExpress](https://www.aliexpress.com/item/1005009270132403.html) |
+| **Battery** | MakerFocus 3.7V 3000mAh LiPo (pack of 4), Micro JST 1.5 connection with protection board | $34.34 | [MakerFocus](https://www.makerfocus.com/products/makerfocus-3-7v-3000mah-lithium-rechargeable-battery-1s-3c-lipo-battery-pack-of-4?variant=44823607541998) |
+| **Antenna** | Gizont 167CM 915MHz SMA M | $10.68 | [AliExpress](https://www.aliexpress.com/item/1005004607615001.html) (make sure you select the right antenna when opening the link) |
+
+</div>
+
+*Approximate total cost:* **$95.68 CAD**
+
+*Prices were recorded when this list was compiled (check the linked page for the current price and date). They will vary and may include shipping costs, so confirm with the links. MakerFocus batteries are shipped from China with no duties.*
+
+!!! warning "Case for the example DIY build"
+    This DIY build example does not include a case. For 3D-printable cases, check out **[Alley Cat's models](https://www.printables.com/@AlleyCat/models)**. They are excellent for custom companion node builds. Make sure the case you choose will fit the 3000 mAh battery and the right-angle IPEX to SMA connector.
+
+If you are in the Ottawa area, you can also purchase this build fully assembled locally from [Space Hedgehog](https://space-hedgehog.com/).
+
+## Standalone nodes
+
+There are standalone devices such as the **T-Deck**, but we recommend starting with a phone-paired companion node instead. Standalone units tend to be more expensive, the UI is not as smooth as the mobile app, and they still have quirks and firmware limitations that can make them challenging for beginners.
+
+### Available standalone devices
+
+<div class="mc-table-wrap" markdown>
+
+| Product | Notes | Link |
+|---|---|---|
+| **LilyGO T-LORA Pager** | A compact standalone LoRa messaging device styled like a classic pager. Useful for simple off-grid communication without needing a smartphone. | [LilyGO Store](https://lilygo.cc/en-ca/products/t-lora-pager) |
+| **LilyGO T-Deck Plus** | Updated version of the T-Deck with improved specs and refinements. Built with MeshCore in mind. **However:** the built-in trackball is a major downside and many users dislike it. | [LilyGO Store](https://lilygo.cc/products/t-deck-plus-meshtastic) |
+
+</div>
 
 ## Before buying
 

--- a/docs/hardware/wire-connector-types.fr.md
+++ b/docs/hardware/wire-connector-types.fr.md
@@ -1,0 +1,36 @@
+---
+title: Types de connecteurs de fils
+description: Identifiez les petits connecteurs fil-à-carte utilisés dans les projets de répéteurs de la communauté avant de commander ou de sertir.
+audience:
+  - repeater-builder
+task: identify-wire-connector
+scope: ottawa-field-practice
+status: draft
+status_notice: false
+owner: docs-hardware
+last_reviewed: 2026-09-02
+review_by: 2027-03-02
+difficulty: intermediate
+estimated_time: 3-5 minutes
+destructive: false
+page_styles:
+  - assets/styles/devices-builds.css?v=20260728-1
+---
+
+# Types de connecteurs de fils
+
+*Page en cours de rédaction.*
+
+Voici quelques connecteurs de fils utilisés dans nos projets de répéteurs. Confirmez le pas et la polarité dans la documentation de l’appareil avant de commander ou de sertir un câble correspondant.
+
+<div class="mc-table-wrap" markdown>
+
+| Nom du connecteur | Pas | Appareils qui l’utilisent |
+|-------------------|-----|---------------------------|
+| Molex PicoBlade 1x02P | 1,25 mm | Ikoka Stick |
+| JST ZHR-2 | 1,5 mm | Connecteur solaire du RAK19007 |
+| JST PHR-2 | 2,0 mm | Connecteur de pile du RAK19007 |
+
+</div>
+
+Ces connecteurs apparaissent dans le [répéteur solaire de 300 mW](repeater-solar-300mw-diy-build.md) et le [répéteur solaire de 1 W](repeater-solar-1w-diy-build.md).

--- a/docs/hardware/wire-connector-types.fr.md
+++ b/docs/hardware/wire-connector-types.fr.md
@@ -8,7 +8,7 @@ scope: ottawa-field-practice
 status: draft
 status_notice: false
 owner: docs-hardware
-last_reviewed: 2026-09-02
+last_reviewed: 2026-09-03
 review_by: 2027-03-02
 difficulty: intermediate
 estimated_time: 3-5 minutes
@@ -18,8 +18,6 @@ page_styles:
 ---
 
 # Types de connecteurs de fils
-
-*Page en cours de rédaction.*
 
 Voici quelques connecteurs de fils utilisés dans nos projets de répéteurs. Confirmez le pas et la polarité dans la documentation de l’appareil avant de commander ou de sertir un câble correspondant.
 

--- a/docs/hardware/wire-connector-types.md
+++ b/docs/hardware/wire-connector-types.md
@@ -8,7 +8,7 @@ scope: ottawa-field-practice
 status: draft
 status_notice: false
 owner: docs-hardware
-last_reviewed: 2026-09-02
+last_reviewed: 2026-09-03
 review_by: 2027-03-02
 difficulty: intermediate
 estimated_time: 3-5 minutes
@@ -19,13 +19,11 @@ page_styles:
 
 # Wire connector types
 
-*Page in progress.*
-
 Here are some wire connectors used across our repeater builds. Confirm the pitch and polarity against the device documentation before ordering or crimping a mating cable.
 
 <div class="mc-table-wrap" markdown>
 
-| Connector name | Size | Devices that use it |
+| Connector name | Pitch | Devices that use it |
 |----------------|------|---------------------|
 | Molex PicoBlade 1x02P | 1.25 mm | Ikoka Stick |
 | JST ZHR-2 | 1.5 mm | RAK19007 solar connector |

--- a/docs/hardware/wire-connector-types.md
+++ b/docs/hardware/wire-connector-types.md
@@ -1,0 +1,36 @@
+---
+title: Wire connector types
+description: Identify the small wire-to-board connectors used across the community repeater builds before ordering or crimping.
+audience:
+  - repeater-builder
+task: identify-wire-connector
+scope: ottawa-field-practice
+status: draft
+status_notice: false
+owner: docs-hardware
+last_reviewed: 2026-09-02
+review_by: 2027-03-02
+difficulty: intermediate
+estimated_time: 3-5 minutes
+destructive: false
+page_styles:
+  - assets/styles/devices-builds.css?v=20260728-1
+---
+
+# Wire connector types
+
+*Page in progress.*
+
+Here are some wire connectors used across our repeater builds. Confirm the pitch and polarity against the device documentation before ordering or crimping a mating cable.
+
+<div class="mc-table-wrap" markdown>
+
+| Connector name | Size | Devices that use it |
+|----------------|------|---------------------|
+| Molex PicoBlade 1x02P | 1.25 mm | Ikoka Stick |
+| JST ZHR-2 | 1.5 mm | RAK19007 solar connector |
+| JST PHR-2 | 2.0 mm | RAK19007 battery connector |
+
+</div>
+
+These connectors appear in the [300 mW solar repeater build](repeater-solar-300mw-diy-build.md) and the [1 W solar repeater build](repeater-solar-1w-diy-build.md).

--- a/docs/meshcore/general-overview.fr.md
+++ b/docs/meshcore/general-overview.fr.md
@@ -8,7 +8,7 @@ task: understand-meshcore-roles
 scope: canada-baseline
 status: draft
 owner: docs-ux
-last_reviewed: 2026-07-22
+last_reviewed: 2026-09-02
 review_by: 2026-10-17
 difficulty: beginner
 estimated_time: 5-10 minutes
@@ -19,6 +19,15 @@ page_styles:
 # Qu’est-ce que MeshCore?
 
 MeshCore est un réseau maillé LoRa. Le micrologiciel d’un appareil lui attribue un rôle précis.
+
+!!! warning "Scission du projet MeshCore : utilisez les liens officiels"
+    À la suite d’événements récents au sein de l’équipe de développement de MeshCore, le projet s’est scindé. Pour rester sur la voie officielle, utilisez uniquement :
+
+    - **Outil de programmation et blogue :** [meshcore.io](https://meshcore.io/){ target="_blank" rel="noopener" }
+    - **Code source :** [github.com/meshcore-dev/MeshCore](https://github.com/meshcore-dev/MeshCore){ target="_blank" rel="noopener" }
+    - **Discord (nommé « MeshCore.io ») :** [discord.com/invite/fUfWevRXAg](https://discord.com/invite/fUfWevRXAg){ target="_blank" rel="noopener" }
+
+    Pour en savoir plus sur la scission : [The Split, blog.meshcore.io](https://blog.meshcore.io/2026/04/23/the-split){ target="_blank" rel="noopener" } (en anglais).
 
 ## Rôles des appareils
 

--- a/docs/meshcore/general-overview.md
+++ b/docs/meshcore/general-overview.md
@@ -8,7 +8,7 @@ task: understand-meshcore-roles
 scope: canada-baseline
 status: draft
 owner: docs-ux
-last_reviewed: 2026-07-22
+last_reviewed: 2026-09-02
 review_by: 2026-10-17
 difficulty: beginner
 estimated_time: 5-10 minutes
@@ -19,6 +19,15 @@ page_styles:
 # What is MeshCore?
 
 MeshCore is a LoRa mesh network. A device's firmware gives it a specific job.
+
+!!! warning "MeshCore project split, use the official links"
+    Due to recent events in the MeshCore development team, the project has split. To stay on the official track, please only use:
+
+    - **Flashing tool and blog:** [meshcore.io](https://meshcore.io/){ target="_blank" rel="noopener" }
+    - **Source code:** [github.com/meshcore-dev/MeshCore](https://github.com/meshcore-dev/MeshCore){ target="_blank" rel="noopener" }
+    - **Discord (named "MeshCore.io"):** [discord.com/invite/fUfWevRXAg](https://discord.com/invite/fUfWevRXAg){ target="_blank" rel="noopener" }
+
+    Read more about the split: [The Split, blog.meshcore.io](https://blog.meshcore.io/2026/04/23/the-split){ target="_blank" rel="noopener" }.
 
 ## Device roles
 

--- a/docs/start/choose-a-goal.fr.md
+++ b/docs/start/choose-a-goal.fr.md
@@ -8,7 +8,7 @@ task: choose-device-role
 scope: upstream-meshcore
 status: verified
 owner: docs-ux
-last_reviewed: 2026-09-02
+last_reviewed: 2026-09-03
 review_by: 2027-07-19
 tested_with:
   content_baseline: f608cfe
@@ -23,9 +23,9 @@ Choisissez l’appareil selon ce qu’il doit faire.
 
 | Type | À quoi sert-il? | Relaie le trafic du réseau? | Utilisation habituelle | Configuration |
 |---|---|---:|---|---|
-| Appareil compagnon | Envoyer et recevoir des messages | Non | Mobile; souvent jumelé à un téléphone | [Configurer un compagnon](companion.md) |
+| Appareil compagnon | Envoyer et recevoir des messages | Normalement non | Mobile; souvent jumelé à un téléphone | [Configurer un compagnon](companion.md) |
 | Répéteur | Améliorer la couverture locale | Oui | Fixe et alimenté en continu | [Configurer un répéteur](repeater.md) |
-| Serveur de salon | Garder un salon partagé accessible | Non | Fixe et alimenté en continu | [Configurer un serveur de salon](room-server.md) |
+| Serveur de salon | Garder un salon partagé accessible | Possible, mais déconseillé | Fixe et alimenté en continu | [Configurer un serveur de salon](room-server.md) |
 | Observateur | Transmettre à CoreScope les données radio captées | Non | Fixe; les besoins varient selon la méthode | [Configurer un observateur](observer.md) |
 
 ## Détails des rôles
@@ -35,20 +35,18 @@ Choisissez l’appareil selon ce qu’il doit faire.
 - Fonctionnent sur pile ou par USB.
 - Se jumellent habituellement à un téléphone intelligent par Bluetooth pour la messagerie.
 - Les appareils autonomes comme le T-Deck ont un écran et un clavier, mais nous ne les recommandons pas aux débutants, car leur micrologiciel est encore rudimentaire.
-- Les compagnons ne routent **pas** les paquets. Ils peuvent communiquer directement entre eux, mais **seuls les répéteurs** assurent le routage dans le réseau MeshCore.
+- Ne routent normalement pas les paquets. Le mode de répétition des compagnons est réservé à certains usages hors réseau; laissez-le désactivé sur un réseau public établi, sauf indication locale contraire.
 
 **Les répéteurs** sont des installations fixes, généralement montées en hauteur (toit, tour, mât), qui étendent la portée et relient les segments du réseau.
 
 - Fonctionnent en continu sur le secteur ou à l’énergie solaire. La plupart des répéteurs d’Ottawa sont solaires.
-- Forment la **dorsale** stable du réseau.
-- Sont les **seuls appareils** qui routent les paquets.
+- Forment la **dorsale** de routage recommandée pour un réseau établi.
 
 **Les serveurs de salon** utilisent un micrologiciel spécialisé qui fonctionne comme un salon de clavardage persistant ou un mini-BBS.
 
-- Conservent les **32 derniers messages** qui leur ont été envoyés.
-- Lorsqu’un compagnon se connecte, il récupère les messages conservés, un peu comme on consulte une boîte de réception.
-- Ils peuvent techniquement répéter, mais c’est fortement déconseillé. Ottawa désactive la répétition sur les serveurs de salon, et les développeurs ont envisagé de retirer complètement cette option.
-- Les serveurs de salon ne sont **pas de vrais répéteurs** et n’offrent pas plusieurs de leurs fonctions. Utilisez-les comme babillards ou nœuds de clavardage partagés, et non comme répéteurs.
+- Lorsqu’un compagnon se connecte, il peut récupérer jusqu’à **32 messages non lus**, un peu comme dans une boîte de réception.
+- Peuvent répéter, mais ce n’est pas recommandé. À Ottawa, cette fonction est désactivée et des répéteurs distincts sont utilisés.
+- N’offrent pas toutes les fonctions de répétition et d’administration à distance. Utilisez-les comme salons de messages partagés, et non comme répéteurs du réseau.
 
 Vous découvrez MeshCore? Commencez par un
 [appareil compagnon](companion.md). Avant d’acheter du matériel ou d’installer

--- a/docs/start/choose-a-goal.fr.md
+++ b/docs/start/choose-a-goal.fr.md
@@ -8,7 +8,7 @@ task: choose-device-role
 scope: upstream-meshcore
 status: verified
 owner: docs-ux
-last_reviewed: 2026-07-22
+last_reviewed: 2026-09-02
 review_by: 2027-07-19
 tested_with:
   content_baseline: f608cfe
@@ -27,6 +27,28 @@ Choisissez l’appareil selon ce qu’il doit faire.
 | Répéteur | Améliorer la couverture locale | Oui | Fixe et alimenté en continu | [Configurer un répéteur](repeater.md) |
 | Serveur de salon | Garder un salon partagé accessible | Non | Fixe et alimenté en continu | [Configurer un serveur de salon](room-server.md) |
 | Observateur | Transmettre à CoreScope les données radio captées | Non | Fixe; les besoins varient selon la méthode | [Configurer un observateur](observer.md) |
+
+## Détails des rôles
+
+**Les appareils compagnons** sont les petits appareils personnels (portatifs ou mobiles) qui permettent à un utilisateur de se connecter au réseau maillé.
+
+- Fonctionnent sur pile ou par USB.
+- Se jumellent habituellement à un téléphone intelligent par Bluetooth pour la messagerie.
+- Les appareils autonomes comme le T-Deck ont un écran et un clavier, mais nous ne les recommandons pas aux débutants, car leur micrologiciel est encore rudimentaire.
+- Les compagnons ne routent **pas** les paquets. Ils peuvent communiquer directement entre eux, mais **seuls les répéteurs** assurent le routage dans le réseau MeshCore.
+
+**Les répéteurs** sont des installations fixes, généralement montées en hauteur (toit, tour, mât), qui étendent la portée et relient les segments du réseau.
+
+- Fonctionnent en continu sur le secteur ou à l’énergie solaire. La plupart des répéteurs d’Ottawa sont solaires.
+- Forment la **dorsale** stable du réseau.
+- Sont les **seuls appareils** qui routent les paquets.
+
+**Les serveurs de salon** utilisent un micrologiciel spécialisé qui fonctionne comme un salon de clavardage persistant ou un mini-BBS.
+
+- Conservent les **32 derniers messages** qui leur ont été envoyés.
+- Lorsqu’un compagnon se connecte, il récupère les messages conservés, un peu comme on consulte une boîte de réception.
+- Ils peuvent techniquement répéter, mais c’est fortement déconseillé. Ottawa désactive la répétition sur les serveurs de salon, et les développeurs ont envisagé de retirer complètement cette option.
+- Les serveurs de salon ne sont **pas de vrais répéteurs** et n’offrent pas plusieurs de leurs fonctions. Utilisez-les comme babillards ou nœuds de clavardage partagés, et non comme répéteurs.
 
 Vous découvrez MeshCore? Commencez par un
 [appareil compagnon](companion.md). Avant d’acheter du matériel ou d’installer

--- a/docs/start/choose-a-goal.md
+++ b/docs/start/choose-a-goal.md
@@ -8,7 +8,7 @@ task: choose-device-role
 scope: upstream-meshcore
 status: verified
 owner: docs-ux
-last_reviewed: 2026-09-02
+last_reviewed: 2026-09-03
 review_by: 2027-07-19
 tested_with:
   content_baseline: f608cfe
@@ -23,9 +23,9 @@ Choose a role based on the job the device will do.
 
 | Role | Use it for | Relays mesh traffic? | Usually | Setup |
 |---|---|---:|---|---|
-| Companion | Send and receive messages | No | Mobile; often pairs with a phone | [Set up a companion](companion.md) |
+| Companion | Send and receive messages | Normally no | Mobile; often pairs with a phone | [Set up a companion](companion.md) |
 | Repeater | Improve local coverage | Yes | Fixed with continuous power | [Set up a repeater](repeater.md) |
-| Room server | Keep a shared room available | No | Fixed with continuous power | [Set up a room server](room-server.md) |
+| Room server | Keep a shared room available | Can, but not recommended | Fixed with continuous power | [Set up a room server](room-server.md) |
 | Observer | Send heard network data to CoreScope | No | Fixed; requirements vary | [Set up an observer](observer.md) |
 
 ## Role details
@@ -35,20 +35,18 @@ Choose a role based on the job the device will do.
 - Run on battery or USB power.
 - Usually pair with a smartphone over Bluetooth for messaging.
 - Standalone options like the T-Deck include a screen and keyboard, but we don't recommend them for beginners since the firmware is still rough.
-- Companion nodes do **not** route packets. They can communicate directly with each other, but **only repeaters** perform routing across the MeshCore network.
+- Normally do not route packets. Client repeat is a limited off-grid feature; leave it off on an established public mesh unless local guidance says otherwise.
 
 **Repeaters** are fixed installations, typically mounted at elevation (rooftop, tower, mast), that extend range and link mesh segments.
 
 - Run continuously on mains or solar power. Most Ottawa repeaters operate on solar.
-- Form the stable **backbone** of the network.
-- Are the **only devices** that perform packet routing.
+- Form the recommended routing **backbone** for an established mesh.
 
 **Room servers** run specialized firmware that functions like a persistent chat room or mini-BBS.
 
-- Store the last **32 messages** sent to them.
-- When a companion connects, it retrieves the stored messages, similar to checking an inbox.
-- While they technically can repeat, this is strongly discouraged. Ottawa disables repeat on room servers, and the developers have discussed removing the option entirely.
-- Room servers are **not full repeaters** and lack many repeater features. Use them as static message boards or shared chat nodes, not as repeaters.
+- When a companion connects, it can retrieve up to **32 unseen messages**, similar to checking an inbox.
+- Can repeat, but this is not recommended. Ottawa keeps repeat disabled on room servers and uses separate repeaters.
+- Lack several repeater and remote-administration features. Use them as shared message rooms, not as network repeaters.
 
 New to MeshCore? Start with a [companion](companion.md). Before buying or
 flashing, confirm that the setup guide supports your device.

--- a/docs/start/choose-a-goal.md
+++ b/docs/start/choose-a-goal.md
@@ -8,7 +8,7 @@ task: choose-device-role
 scope: upstream-meshcore
 status: verified
 owner: docs-ux
-last_reviewed: 2026-07-22
+last_reviewed: 2026-09-02
 review_by: 2027-07-19
 tested_with:
   content_baseline: f608cfe
@@ -27,6 +27,28 @@ Choose a role based on the job the device will do.
 | Repeater | Improve local coverage | Yes | Fixed with continuous power | [Set up a repeater](repeater.md) |
 | Room server | Keep a shared room available | No | Fixed with continuous power | [Set up a room server](room-server.md) |
 | Observer | Send heard network data to CoreScope | No | Fixed; requirements vary | [Set up an observer](observer.md) |
+
+## Role details
+
+**Companion nodes** are the small personal devices (handheld or portable) that let a user connect to the mesh.
+
+- Run on battery or USB power.
+- Usually pair with a smartphone over Bluetooth for messaging.
+- Standalone options like the T-Deck include a screen and keyboard, but we don't recommend them for beginners since the firmware is still rough.
+- Companion nodes do **not** route packets. They can communicate directly with each other, but **only repeaters** perform routing across the MeshCore network.
+
+**Repeaters** are fixed installations, typically mounted at elevation (rooftop, tower, mast), that extend range and link mesh segments.
+
+- Run continuously on mains or solar power. Most Ottawa repeaters operate on solar.
+- Form the stable **backbone** of the network.
+- Are the **only devices** that perform packet routing.
+
+**Room servers** run specialized firmware that functions like a persistent chat room or mini-BBS.
+
+- Store the last **32 messages** sent to them.
+- When a companion connects, it retrieves the stored messages, similar to checking an inbox.
+- While they technically can repeat, this is strongly discouraged. Ottawa disables repeat on room servers, and the developers have discussed removing the option entirely.
+- Room servers are **not full repeaters** and lack many repeater features. Use them as static message boards or shared chat nodes, not as repeaters.
 
 New to MeshCore? Start with a [companion](companion.md). Before buying or
 flashing, confirm that the setup guide supports your device.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -132,6 +132,8 @@ plugins:
             Antennas: Antennes
             Solar repeater build: Répéteur solaire
             Build a 300 mW repeater: Monter un répéteur de 300 mW
+            Build a 1 W repeater (experimental): Monter un répéteur de 1 W (expérimental)
+            Wire connector types: Types de connecteurs de fils
             Install a repeater: Installer un répéteur
             Mounting options: Options de montage
             Firmware: Micrologiciel
@@ -185,7 +187,6 @@ plugins:
         resources/getting-started.md: start/index.md
         meshcore/firmware-rak-custom-display.md: meshcore/flash-companion.md
         meshcore/firmware-heltec-v3-wifi.md: meshcore/flash-companion.md
-        hardware/wire-connector-types.md: hardware/recommended-repeaters.md
         hardware/repeater-solar-batteries.md: hardware/recommended-repeaters.md
         hardware/overview.md: hardware/index.md
         meshcore/general-meshcore-roles.md: start/choose-a-goal.md
@@ -240,6 +241,8 @@ nav:
       - Antennas: hardware/recommended-antenna.md
       - Solar repeater build:
           - Build a 300 mW repeater: hardware/repeater-solar-300mw-diy-build.md
+          - Build a 1 W repeater (experimental): hardware/repeater-solar-1w-diy-build.md
+          - Wire connector types: hardware/wire-connector-types.md
       - Install a repeater:
           - Mounting options: hardware/repeater-mounting-options.md
       - Firmware:

--- a/tests/content/analyzer-journey.test.mjs
+++ b/tests/content/analyzer-journey.test.mjs
@@ -134,6 +134,24 @@ test("privacy pages state ownership, access, the account inventory, and the unkn
   assert.match(french, /mettre ce tableau à jour chaque\s+fois qu’ils créent ou retirent un compte en lecture seule/i);
 });
 
+test("broker reference lists every administrator and public contact in both languages", () => {
+  const english = read("docs/analyzer/broker-reference.md");
+  const french = read("docs/analyzer/broker-reference.fr.md");
+  const contacts = [
+    ["n30nex", "https://github.com/n30nex"],
+    ["Mr. Alderson", "https://github.com/MrAlders0n"],
+    ["Ded", "https://github.com/446564"],
+    ["Kranic", "https://forum.meshcore.ca/u/djkranic"],
+  ];
+
+  for (const [administrator, contact] of contacts) {
+    for (const page of [english, french]) {
+      assert.ok(page.includes(administrator), `missing administrator ${administrator}`);
+      assert.ok(page.includes(contact), `missing contact ${contact}`);
+    }
+  }
+});
+
 test("verification distinguishes connectivity from an observed packet", () => {
   const source = read("docs/analyzer/verify.md");
   assert.match(source, /broker connection proves only/i);

--- a/tests/content/analyzer-journey.test.mjs
+++ b/tests/content/analyzer-journey.test.mjs
@@ -126,10 +126,16 @@ test("privacy pages state ownership, access, the account inventory, and the unkn
   ]) {
     assert.match(source, new RegExp(phrase, "i"));
   }
-  for (const service of ["Beacon (`dev.meshcore.ca`)", "CoreScope (`live.meshcore.ca`)"]) {
+  for (const service of [
+    "Beacon (`dev.meshcore.ca`)",
+    "CoreScope (`live.meshcore.ca`)",
+    "[Quinte Mesh](https://quintemesh.ca/)",
+  ]) {
     assert.ok(source.includes(service), `English inventory missing ${service}`);
     assert.ok(french.includes(service), `French inventory missing ${service}`);
   }
+  assert.ok(source.includes("hansimgamr"), "English inventory missing the Quinte Mesh operator");
+  assert.ok(french.includes("hansimgamr"), "French inventory missing the Quinte Mesh operator");
   assert.match(source, /update this table whenever they create or remove a read-only account/i);
   assert.match(french, /mettre ce tableau à jour chaque\s+fois qu’ils créent ou retirent un compte en lecture seule/i);
 });

--- a/tests/content/devices-builds.test.mjs
+++ b/tests/content/devices-builds.test.mjs
@@ -120,10 +120,14 @@ test("build guides provide staged, printable safety checks and records", () => {
   }
 });
 
-test("experimental and legacy workflows stay outside primary navigation", () => {
+test("the 1 W build is listed in navigation while legacy workflows stay outside it", () => {
   const config = read("mkdocs.yml");
 
-  assert.doesNotMatch(config, /repeater-solar-1w-diy-build\.md/);
+  assert.match(
+    config,
+    /Build a 1 W repeater \(experimental\): hardware\/repeater-solar-1w-diy-build\.md/,
+  );
+  assert.match(config, /Wire connector types: hardware\/wire-connector-types\.md/);
   assert.doesNotMatch(config, /generate-repeater-id\.md/);
   assert.ok(existsSync(resolve(root, "docs/hardware/repeater-solar-1w-diy-build.md")));
   assert.ok(existsSync(resolve(root, "docs/meshcore/generate-repeater-id.md")));

--- a/tests/content/learn-content.test.mjs
+++ b/tests/content/learn-content.test.mjs
@@ -58,7 +58,9 @@ test("MeshCore overview explains all four roles and routes users forward", () =>
   }
   assert.match(markdown, /\[Compare device roles\]\(\.\.\/start\/choose-a-goal\.md\)/);
   assert.match(markdown, /\[Choose a role and start setup\]\(\.\.\/start\/index\.md\)/);
-  assert.doesNotMatch(markdown, /project has split|legacy|Ottawa/i);
+  assert.match(markdown, /MeshCore project split, use the official links/);
+  assert.match(markdown, /https:\/\/blog\.meshcore\.io\/2026\/04\/23\/the-split/);
+  assert.doesNotMatch(markdown, /legacy|Ottawa/i);
 });
 
 test("FAQ is deep-linkable and refers changing settings to canonical sources", () => {

--- a/tests/content/p0-content-safety.test.mjs
+++ b/tests/content/p0-content-safety.test.mjs
@@ -60,7 +60,6 @@ test("unsafe and incomplete legacy pages are removed from the content tree", () 
     "docs/meshcore/firmware-rak-custom-display.md",
     "docs/meshcore/firmware-heltec-v3-wifi.md",
     "docs/hardware/repeater-solar-batteries.md",
-    "docs/hardware/wire-connector-types.md",
   ]) {
     assert.equal(existsSync(resolve(root, path)), false, `${path} must not remain searchable`);
   }

--- a/tests/content/start-journeys.test.mjs
+++ b/tests/content/start-journeys.test.mjs
@@ -166,7 +166,6 @@ test("retired visitor pages use canonical redirects instead of searchable bridge
     ["resources/getting-started.md", "start/index.md"],
     ["meshcore/firmware-rak-custom-display.md", "meshcore/flash-companion.md"],
     ["meshcore/firmware-heltec-v3-wifi.md", "meshcore/flash-companion.md"],
-    ["hardware/wire-connector-types.md", "hardware/recommended-repeaters.md"],
     ["hardware/repeater-solar-batteries.md", "hardware/recommended-repeaters.md"],
   ]) {
     assert.match(config, new RegExp(`${oldPath.replaceAll("/", "\\/")}: ${currentPath.replaceAll("/", "\\/")}`));

--- a/ux-overhaul/ROUTE-MIGRATION.md
+++ b/ux-overhaul/ROUTE-MIGRATION.md
@@ -29,10 +29,10 @@ changes navigation and canonical journeys before moving source files.
 | `/hardware/recommended-repeaters/` | Repeater recommendations | Preserve |
 | `/hardware/recommended-antenna/` | Antenna recommendations | Preserve |
 | `/hardware/repeater-solar-300mw-diy-build/` | 300 mW build | Preserve |
-| `/hardware/repeater-solar-1w-diy-build/` | 1 W build | Preserve |
+| `/hardware/repeater-solar-1w-diy-build/` | 1 W build | Preserve; listed in navigation as experimental (2026-09-02) |
 | `/hardware/repeater-mounting-options/` | Mounting guide | Preserve after repair |
 | `/hardware/repeater-solar-batteries/` | Power guide | Remove from nav until reviewed; URL retained |
-| `/hardware/wire-connector-types/` | Connector reference | Remove from nav until reviewed; URL retained |
+| `/hardware/wire-connector-types/` | Connector reference | Restored as a page and nav entry (2026-09-02) |
 | `/meshcore/flash-companion/` | Companion flash journey | Preserve and rebuild safely |
 | `/meshcore/flash-repeater/` | Repeater flash journey | Preserve and rebuild safely |
 | `/meshcore/flash-room-server/` | Room server journey | Preserve and rebuild safely |


### PR DESCRIPTION
This restores useful community guidance that was trimmed during the site overhaul, keeps the overhaul's safety and verification structure, and folds the MQTT broker reference work from #88 into one reviewable change.

## Restored and updated

- Restores the bilingual wire-connector reference and adds it to the Devices & Builds navigation.
- Adds the bilingual experimental 1 W solar repeater guide to the navigation while keeping its electrical, RF, battery, and site-review gates.
- Restores the companion and antenna recommendations, prices, local suppliers, connector warnings, and DIY companion example.
- Restores the MeshCore project-split notice and expanded device-role guidance.
- Restores the bilingual MQTT broker administrator contacts.
- Documents the current read-only subscriber inventory, including `hansimgamr` for [Quinte Mesh](https://quintemesh.ca/).

## Corrections made during review

- Describes dedicated repeaters as the recommended routing backbone without incorrectly claiming that room servers can never repeat.
- Corrects the room-server history wording to 32 unseen messages.
- Makes clear that the WisMesh Tag ships with Meshtastic and must be flashed with MeshCore before use.
- Limits replacement-antenna advice to devices with removable antennas.
- Removes stale claims about a cheaper unflashed T-Echo, guaranteed duty treatment, and the T-Deck Plus being designed for MeshCore.
- Replaces the unfinished-page label on the connector reference and names connector pitch correctly.

The role and firmware corrections were checked against the current [MeshCore FAQ](https://github.com/meshcore-dev/MeshCore/blob/main/docs/faq.md), [MeshCore configurator](https://github.com/meshcore-dev/config.meshcore.io/blob/main/index.html), [official MeshCore hardware/flasher page](https://meshcore.io/), and [RAK WisMesh Tag documentation](https://docs.rakwireless.com/product-categories/meshtastic/wismesh-tag/quickstart/).

## Validation

- `node --test tests/content/*.test.mjs` — 74 passed
- `python -m unittest discover -s tests/content` — 14 passed
- strict bilingual site build and built-link validation — 129 pages and 13,170 local references passed
- Chromium browser suite — 66 passed, 5 intentionally skipped
- `git diff --check` — clean

PR #88 is included in this branch and can be closed once this push is confirmed.