### PR TITLE
Fix region setup and simplify the bilingual documentation

### DIFF
--- a/.github/ISSUE_TEMPLATE/community_idea.yml
+++ b/.github/ISSUE_TEMPLATE/community_idea.yml
@@ -24,7 +24,7 @@ body:
         - Feature or project idea
         - Other community feedback
     validations:
-      required: true
+      required: false
 
   - type: dropdown
     id: experience
@@ -37,7 +37,7 @@ body:
         - Repeater, room server, or observer operator
         - Developer or documentation contributor
     validations:
-      required: true
+      required: false
 
   - type: input
     id: summary
@@ -71,7 +71,7 @@ body:
       description: What should change?
       placeholder: Add...
     validations:
-      required: true
+      required: false
 
   - type: textarea
     id: context

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -154,3 +154,11 @@ jobs:
         run: |
           export CHROME_PATH="$(command -v google-chrome || command -v google-chrome-stable)"
           npm run audit:lighthouse
+
+      - name: Save Lighthouse reports
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: lighthouse-reports
+          path: .tmp/lighthouse/*.json
+          retention-days: 7

--- a/README.md
+++ b/README.md
@@ -1,0 +1,73 @@
+# MeshCore Canada
+
+Community documentation and network tools for [meshcore.ca](https://meshcore.ca/),
+in English and French. Built with MkDocs Material and small browser scripts.
+
+## Work locally
+
+Use Python 3.13 and Node.js 22.19 or newer. From the repository root:
+
+```sh
+python -m pip install -r requirements-docs.txt
+npm ci
+npm run docs:build
+python -m http.server 4173 --bind 127.0.0.1 --directory .tmp/site
+```
+
+Open `http://127.0.0.1:4173/`. Rebuild after editing. Build output belongs in
+`.tmp/`, not in a commit. `npm run docs:build:preview` also checks subpath hosting.
+
+## Where to make changes
+
+- Pages: `docs/`. Update each English `.md` and French `.fr.md` pair; retain old
+  heading anchors when changing titles.
+- Navigation, theme, and shared templates: `mkdocs.yml` and `overrides/`.
+- Community listings: `data/communities.json` and `data/communities.fr.json`.
+  Run `python scripts/validate-communities.py --write` after editing the source.
+  It generates the directory pages and `docs/assets/radio-profiles.json`.
+- Region tools: `docs/assets/regions/` and `docs/config/editor/`.
+  Follow the boundary proposal workflow; do not hand-edit generated geography.
+- Broker settings: `docs/analyzer/observer-config.json`. The build generates the
+  broker reference table from this file, including its no-JavaScript version.
+- Anonymous submissions: `tools/region-proposal-gateway/`. The site and gateway
+  deploy separately; check the gateway README before changing their contract.
+
+Never commit credentials, private keys, precise private locations, or test
+submissions containing personal information. Human maintainers review changes
+before publication; an automated test is not hardware or policy approval.
+
+## Check a change
+
+```sh
+python scripts/validate-content.py
+python scripts/validate-communities.py
+python scripts/validate_community_submission.py
+python -m unittest discover -s tests/content -p "test_*.py"
+npm run test:content
+npm run test:editor
+npm run check:links
+npx playwright install chromium firefox webkit
+npm run test:browser
+npm run audit:lighthouse
+```
+
+The broker-helper tests need Bash and PowerShell (`pwsh`); on Windows they use
+Git Bash. They run in temporary directories, do not install software, and never
+connect to a real broker. Browser submission tests intercept requests locally.
+
+For region, gateway, or automation changes, also run:
+
+```sh
+python -m pip install -r scripts/requirements-regions.txt
+python -m pip install -r tools/region-proposal-gateway/requirements.txt
+node scripts/validate-regions.cjs
+python scripts/verify-region-geometry.py
+python scripts/verify-region-geometry.py --partition docs/assets/regions/canada-region-partition-digital.geojson
+python -m unittest discover -s tools/region-proposal-gateway/tests
+python -m unittest discover -s tests/automation
+```
+
+The quality workflow runs these checks on pull requests. Publishing is a separate
+reviewed workflow; opening a PR does not authorize deploying it or changing brokers.
+See [the September audit follow-up](maintenance/site-audit-2026-09-04.md) for the
+current fixes, test coverage, and confirmations still needed from maintainers.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ python -m http.server 4173 --bind 127.0.0.1 --directory .tmp/site
 ```
 
 Open `http://127.0.0.1:4173/`. Rebuild after editing. Build output belongs in
-`.tmp/`, not in a commit. `npm run docs:build:preview` also checks subpath hosting.
+`.tmp/`, not in a commit. `npm run docs:build:preview` builds for subpath hosting.
 
 ## Where to make changes
 

--- a/docs/analyzer/broker-reference.fr.md
+++ b/docs/analyzer/broker-reference.fr.md
@@ -15,8 +15,6 @@ estimated_time: 8 minutes
 destructive: false
 page_styles:
   - assets/styles/analyzer.css?v=20260722-2
-page_scripts:
-  - assets/javascripts/analyzer-broker-reference.js?v=20260722-2
 ---
 
 # Paramètres de connexion des observateurs
@@ -45,10 +43,13 @@ Ces valeurs proviennent de la [configuration commune des observateurs](observer-
       <tbody id="broker-reference-body"></tbody>
     </table>
   </div>
-  <p class="mc-location-status" id="broker-reference-status" role="status">Chargement des paramètres officiels de connexion…</p>
 </div>
 
-Si le tableau ne s’affiche pas, ouvrez [observer-config.json](observer-config.json).
+## Accès en lecture seule
+
+La [liste des comptes MQTT en lecture seule](data-collection-access.md#read-only-mqtt-accounts) indique les abonnés autorisés, dont QuinteMesh. Pour demander un accès, contactez un administrateur ci-dessous.
+
+Les réglages JWT de cette page concernent les **observateurs qui publient des paquets**. Les abonnés en lecture seule utilisent les identifiants et les instructions fournis par un administrateur. N’utilisez pas la clé privée d’un observateur pour cet accès.
 
 ## Administrateurs des courtiers
 

--- a/docs/analyzer/broker-reference.md
+++ b/docs/analyzer/broker-reference.md
@@ -15,8 +15,6 @@ estimated_time: 8 minutes
 destructive: false
 page_styles:
   - assets/styles/analyzer.css?v=20260722-2
-page_scripts:
-  - assets/javascripts/analyzer-broker-reference.js?v=20260722-2
 ---
 
 # Observer connection reference
@@ -44,10 +42,13 @@ These values come from the shared [observer configuration](observer-config.json)
       <tbody id="broker-reference-body"></tbody>
     </table>
   </div>
-  <p class="mc-location-status" id="broker-reference-status" role="status">Loading official connection settings…</p>
 </div>
 
-If the table does not load, open [observer-config.json](observer-config.json).
+## Read-only access
+
+See the [read-only MQTT account list](data-collection-access.md#read-only-mqtt-accounts) for approved subscribers, including QuinteMesh. Ask an administrator below to request access.
+
+The JWT settings on this page are for **observers publishing packets**. Read-only subscribers use the credentials and connection instructions supplied by an administrator. Do not use an observer’s private key for subscriber access.
 
 ## Broker administrators
 

--- a/docs/analyzer/builds/mctomqtt.fr.md
+++ b/docs/analyzer/builds/mctomqtt.fr.md
@@ -63,8 +63,8 @@ Sur un hôte à liaison série, l’outil :
 
 Pour la capture d’un compagnon, il met à jour
 `~/.meshcore-packet-capture/.env.local`, crée une sauvegarde horodatée,
-configure les emplacements 1 et 2, désactive les emplacements 3 à 6 et peut
-redémarrer le service de capture.
+met à jour les emplacements MeshCore Canada existants ou utilise des emplacements
+vides. Les autres connexions sont conservées. Il peut redémarrer le service de capture.
 
 Les options d’installation téléchargent et exécutent des programmes
 d’installation distincts provenant des projets d’origine. Ne les utilisez pas
@@ -128,7 +128,7 @@ Après avoir examiné la version actuellement publiée de l’outil, vous pouvez
 exécuter directement ce même fichier :
 
 ```bash
-bash <(curl -fsSL https://meshcore.ca/analyzer/scripts/add-meshcore-ca-broker.sh) --device serial-host --iata YOW
+bash add-meshcore-ca-broker.sh --device serial-host --iata YOW
 ```
 
 La méthode de téléchargement présentée plus haut facilite l’examen et la

--- a/docs/analyzer/builds/mctomqtt.md
+++ b/docs/analyzer/builds/mctomqtt.md
@@ -59,7 +59,7 @@ On a serial host, the helper:
 - adds the primary and backup MeshCore Canada addresses and location code; and
 - restarts `mctomqtt` unless `--no-restart` is used.
 
-For companion capture, it updates `~/.meshcore-packet-capture/.env.local`, makes a timestamped backup, configures slots 1 and 2, disables slots 3–6, and may restart the capture service.
+For companion capture, it updates `~/.meshcore-packet-capture/.env.local`, makes a timestamped backup, updates existing Canada broker slots or uses empty slots, and may restart the capture service.
 
 Install flags download and run separate upstream installers. Do not use them until you have reviewed the named upstream installer too.
 
@@ -114,7 +114,7 @@ The service should stay active without repeated TLS or authentication errors.
 After reviewing the current published helper, you can run that same file directly:
 
 ```bash
-bash <(curl -fsSL https://meshcore.ca/analyzer/scripts/add-meshcore-ca-broker.sh) --device serial-host --iata YOW
+bash add-meshcore-ca-broker.sh --device serial-host --iata YOW
 ```
 
 The downloaded-file method above is easier to review and recover.

--- a/docs/analyzer/builds/mqtt-firmware.fr.md
+++ b/docs/analyzer/builds/mqtt-firmware.fr.md
@@ -15,7 +15,8 @@ destructive: true
 page_styles:
   - assets/styles/analyzer.css?v=20260722-2
 page_scripts:
-  - assets/javascripts/analyzer-command-builder.js?v=20260722-2
+  - assets/javascripts/radio-profiles.js?v=20260904-1
+  - assets/javascripts/analyzer-command-builder.js?v=20260904-1
 ---
 
 # Configurer un observateur MQTT autonome
@@ -100,6 +101,10 @@ propre à la communauté, la configuration canadienne de départ est :
 
 ### 3. Générer les commandes
 
+Ces commandes remplacent les emplacements MQTT **1 et 2**. S’ils servent déjà à un
+autre réseau, ajoutez le Canada dans des emplacements libres avec **Configure via USB**.
+Les emplacements 3 à 6 restent inchangés. La répétition est désactivée par défaut.
+
 L’interface en ligne de commande n’a pas de règle générale documentée pour les
 guillemets. Le générateur rejette les espaces, les guillemets, les barres
 obliques inverses, les caractères de contrôle et les autres valeurs Wi-Fi
@@ -146,11 +151,14 @@ représenter de façon sûre.
     <label class="mc-command-field--wide">
       <strong>Trafic du réseau maillé</strong>
       <select id="observer-repeat">
-        <option value="on">Observer et relayer les paquets</option>
-        <option value="off">Observer seulement</option>
+        <option value="off">Observer seulement (recommandé)</option>
+        <option value="on">Observer et relayer — à coordonner localement</option>
       </select>
     </label>
   </div>
+  <label><strong>Réseau radio</strong><select id="observer-radio"><option value="keep">Conserver les réglages actuels</option></select></label>
+  <p>Choisissez le profil de votre communauté. L’emplacement seul ne détermine pas les réglages radio.</p>
+  <label><strong>Taille de l’identifiant d’annonce</strong><select id="observer-hash"><option value="keep">Conserver les réglages actuels</option><option value="2">3 octets</option><option value="1">2 octets</option><option value="0">1 octet</option></select></label>
   <p class="mc-command-notice" id="observer-location-status" aria-live="polite">Chargement des suggestions d’emplacements canadiens…</p>
   <p class="mc-command-notice" id="observer-secret-help">Le SSID et le mot de passe restent uniquement dans cette page. Ils sont effacés lorsque vous la quittez et masqués dans l’aperçu jusqu’à ce que vous choisissiez de les afficher.</p>
   <div class="mc-command-errors" id="observer-command-errors" role="alert" aria-live="assertive"></div>
@@ -175,23 +183,17 @@ sensibles :
 
 ```text
 set name YOW-Repeater-01
-set radio 910.525,62.5,7,5
-set path.hash.mode 2
 set mqtt.iata YOW
 set wifi.powersave none
 set mqtt1.preset meshcore-ca-1
 set mqtt2.preset meshcore-ca-2
-set mqtt3.preset none
-set mqtt4.preset none
-set mqtt5.preset none
-set mqtt6.preset none
 set mqtt.status on
 set mqtt.packets on
 set mqtt.raw off
 set mqtt.rx on
 set mqtt.tx advert
 set bridge.enabled on
-set repeat on
+set repeat off
 advert
 ```
 
@@ -233,7 +235,7 @@ La carte est correctement configurée lorsque :
 - le code d’emplacement est exact;
 - les préréglages sont `meshcore-ca-1` et `meshcore-ca-2`;
 - la publication des paquets et le mode pont sont activés;
-- le mode de hachage des chemins est `2`.
+- le profil radio et la taille d’identifiant correspondent à vos choix.
 
 ## Vérifier dans CoreScope { #check-in-corescope }
 

--- a/docs/analyzer/builds/mqtt-firmware.md
+++ b/docs/analyzer/builds/mqtt-firmware.md
@@ -15,7 +15,8 @@ destructive: true
 page_styles:
   - assets/styles/analyzer.css?v=20260722-2
 page_scripts:
-  - assets/javascripts/analyzer-command-builder.js?v=20260722-2
+  - assets/javascripts/radio-profiles.js?v=20260904-1
+  - assets/javascripts/analyzer-command-builder.js?v=20260904-1
 ---
 
 # Build a standalone MQTT observer
@@ -88,6 +89,10 @@ Use the local mesh settings. When no community override exists, the Canadian onb
 
 ### 3. Build the commands
 
+These commands replace MQTT slots **1 and 2**. Check those slots first; if they
+serve another network, use **Configure via USB** to add Canada in unused slots.
+Slots 3–6 are left unchanged. Repeating is off unless you choose to enable it.
+
 The CLI has no documented general quoting contract. The builder rejects spaces, quotes, backslashes, control characters, and other ambiguous Wi-Fi values. Use **Configure via USB** for a network it cannot represent safely.
 
 <div class="mc-command-builder" id="observer-command-builder" data-location-source="../../location-codes.json">
@@ -130,11 +135,14 @@ The CLI has no documented general quoting contract. The builder rejects spaces, 
     <label class="mc-command-field--wide">
       <strong>Mesh traffic</strong>
       <select id="observer-repeat">
-        <option value="on">Observe and repeat packets</option>
-        <option value="off">Observe only</option>
+        <option value="off">Observe only (recommended)</option>
+        <option value="on">Observe and repeat packets — coordinate locally first</option>
       </select>
     </label>
   </div>
+  <label><strong>Radio network</strong><select id="observer-radio"><option value="keep">Keep current settings</option></select></label>
+  <p>Choose your community’s profile explicitly. Location alone does not select a radio network.</p>
+  <label><strong>Advert ID size</strong><select id="observer-hash"><option value="keep">Keep current settings</option><option value="2">3 bytes</option><option value="1">2 bytes</option><option value="0">1 byte</option></select></label>
   <p class="mc-command-notice" id="observer-location-status" aria-live="polite">Loading Canadian location suggestions…</p>
   <p class="mc-command-notice" id="observer-secret-help">SSID and password stay in this page only. They are cleared when you leave and hidden from the preview until you reveal them.</p>
   <div class="mc-command-errors" id="observer-command-errors" role="alert" aria-live="assertive"></div>
@@ -152,27 +160,23 @@ Check the non-sensitive summary and redacted preview. Reveal and copy commands o
 
 ### Enter commands by hand
 
+These commands preserve radio settings and presets 3–6, but replace presets 1 and 2. On an existing observer, check those slots first. Choose radio values in the builder above; changes take effect after reboot. Observing does not require repeating. Enable repeating only after coordinating with nearby operators.
+
 If you prefer manual entry, set the non-sensitive values first:
 
 ```text
 set name YOW-Repeater-01
-set radio 910.525,62.5,7,5
-set path.hash.mode 2
 set mqtt.iata YOW
 set wifi.powersave none
 set mqtt1.preset meshcore-ca-1
 set mqtt2.preset meshcore-ca-2
-set mqtt3.preset none
-set mqtt4.preset none
-set mqtt5.preset none
-set mqtt6.preset none
 set mqtt.status on
 set mqtt.packets on
 set mqtt.raw off
 set mqtt.rx on
 set mqtt.tx advert
 set bridge.enabled on
-set repeat on
+set repeat off
 advert
 ```
 
@@ -210,7 +214,7 @@ The board is configured correctly when:
 - the location code is correct;
 - presets are `meshcore-ca-1` and `meshcore-ca-2`;
 - packet publishing and bridge mode are on; and
-- path hash mode is `2`.
+- the radio profile and path hash mode match your explicit choices.
 
 ## Verify in CoreScope
 

--- a/docs/analyzer/builds/pymc.fr.md
+++ b/docs/analyzer/builds/pymc.fr.md
@@ -50,7 +50,9 @@ Notez l’état actuel du service :
 
 ```bash
 sudo systemctl status pymc-repeater --no-pager
-sudo cp -- /etc/pymc_repeater/config.yaml /etc/pymc_repeater/config.yaml.pre-meshcore-ca
+backup="/etc/pymc_repeater/config.yaml.pre-meshcore-ca.$(date -u +%Y%m%dT%H%M%S).$"
+sudo cp --no-clobber -- /etc/pymc_repeater/config.yaml "$backup"
+printf 'Backup: %s\n' "$backup"
 ```
 
 ## Ce qui sera modifié
@@ -140,7 +142,7 @@ bon état ne confirme pas que les paquets se sont rendus à CoreScope.
 Restaurez exactement la sauvegarde créée avant la modification :
 
 ```bash
-sudo cp -- /etc/pymc_repeater/config.yaml.pre-meshcore-ca /etc/pymc_repeater/config.yaml
+sudo cp -- "${backup:?Set backup to the saved backup path first}" /etc/pymc_repeater/config.yaml
 sudo systemctl restart pymc-repeater
 sudo systemctl status pymc-repeater --no-pager
 ```

--- a/docs/analyzer/builds/pymc.md
+++ b/docs/analyzer/builds/pymc.md
@@ -45,7 +45,9 @@ Record the current service state:
 
 ```bash
 sudo systemctl status pymc-repeater --no-pager
-sudo cp -- /etc/pymc_repeater/config.yaml /etc/pymc_repeater/config.yaml.pre-meshcore-ca
+backup="/etc/pymc_repeater/config.yaml.pre-meshcore-ca.$(date -u +%Y%m%dT%H%M%S).$"
+sudo cp --no-clobber -- /etc/pymc_repeater/config.yaml "$backup"
+printf 'Backup: %s\n' "$backup"
 ```
 
 ## What this changes
@@ -128,7 +130,7 @@ Finish with [Check your observer](../verify.md). A healthy systemd service is no
 Restore the exact backup made before editing:
 
 ```bash
-sudo cp -- /etc/pymc_repeater/config.yaml.pre-meshcore-ca /etc/pymc_repeater/config.yaml
+sudo cp -- "${backup:?Set backup to the saved backup path first}" /etc/pymc_repeater/config.yaml
 sudo systemctl restart pymc-repeater
 sudo systemctl status pymc-repeater --no-pager
 ```

--- a/docs/analyzer/data-collection-access.fr.md
+++ b/docs/analyzer/data-collection-access.fr.md
@@ -70,7 +70,7 @@ MeshCore Canada n’offre pas d’abonnement direct général au courtier. L’a
 direct est limité à CoreScope, aux administrateurs des réseaux maillés locaux
 et aux personnes autorisées par les administrateurs de l’infrastructure.
 
-## Comptes MQTT en lecture seule
+## Comptes MQTT en lecture seule { #read-only-mqtt-accounts }
 
 Cet inventaire public répertorie les services qui disposent d’un accès en lecture
 seule aux courtiers MQTT de MeshCore Canada. Il indique le service et

--- a/docs/analyzer/data-collection-access.fr.md
+++ b/docs/analyzer/data-collection-access.fr.md
@@ -80,6 +80,7 @@ l’exploitant, mais jamais les mots de passe ni les jetons.
 |---|---|---|
 | Beacon (`dev.meshcore.ca`) | Exploitants de MeshCore Canada | Visualisation publique des paquets et vérification des identifiants de répéteur |
 | CoreScope (`live.meshcore.ca`) | Exploitants de MeshCore Canada | Outils publics pour les observateurs, les paquets, les nœuds et la carte |
+| [Canadaverse](https://canadaverse.org/) | [n30nex@gmail.com](mailto:n30nex@gmail.com) | Outils régionaux du Grand Toronto et carte CartoLive |
 | [Quinte Mesh](https://quintemesh.ca/) | hansimgamr | Services du réseau communautaire de la région de Quinte |
 
 Les administrateurs de l’infrastructure doivent mettre ce tableau à jour chaque

--- a/docs/analyzer/data-collection-access.md
+++ b/docs/analyzer/data-collection-access.md
@@ -68,6 +68,7 @@ This public inventory lists services with read-only access to the MeshCore Canad
 |---|---|---|
 | Beacon (`dev.meshcore.ca`) | MeshCore Canada operators | Public packet viewer and repeater ID checks |
 | CoreScope (`live.meshcore.ca`) | MeshCore Canada operators | Public observer, packet, node, and map tools |
+| [Canadaverse](https://canadaverse.org/) | [n30nex@gmail.com](mailto:n30nex@gmail.com) | GTA Regional Tools & CartoLive map |
 | [Quinte Mesh](https://quintemesh.ca/) | hansimgamr | Quinte-region community network services |
 
 Infrastructure administrators must update this table whenever they create or remove a read-only account. [Report a missing or outdated entry](https://github.com/MeshCore-ca/MeshCore-Canada/issues/new/choose).

--- a/docs/analyzer/scripts/add-meshcore-ca-broker.sh
+++ b/docs/analyzer/scripts/add-meshcore-ca-broker.sh
@@ -30,8 +30,9 @@ Supported installs:
   - Companion radio via meshcore-packet-capture (.env.local)
 
 Usage:
-  MESHCORE_CA_IATA=YOW bash <(curl -fsSL https://meshcore.ca/analyzer/scripts/add-meshcore-ca-broker.sh)
-  bash <(curl -fsSL https://meshcore.ca/analyzer/scripts/add-meshcore-ca-broker.sh) --iata YOW --device serial-host
+  curl -fsSLo add-meshcore-ca-broker.sh https://meshcore.ca/analyzer/scripts/add-meshcore-ca-broker.sh
+  less add-meshcore-ca-broker.sh
+  bash ./add-meshcore-ca-broker.sh --iata YOW --device serial-host
 
 Options:
   --iata CODE             Real 3-letter IATA airport code.
@@ -537,15 +538,28 @@ set_packetcapture_slot() {
   upsert_env "$file" "PACKETCAPTURE_MQTT${slot}_TOPIC_PACKETS" 'meshcore/{IATA}/{PUBLIC_KEY}/packets'
 }
 
-disable_packetcapture_slot() {
-  local file="$1"
-  local slot="$2"
-  upsert_env "$file" "PACKETCAPTURE_MQTT${slot}_ENABLED" "false"
-  upsert_env "$file" "PACKETCAPTURE_MQTT${slot}_SERVER" ""
+choose_packetcapture_slots() {
+  local file="$1" n server slot1="" slot2="" free=()
+  for n in 1 2 3 4 5 6; do
+    server="$(env_value "$file" "PACKETCAPTURE_MQTT${n}_SERVER" | tr -d '\r')"
+    server="${server#\"}"; server="${server%\"}"
+    server="${server#\'}"; server="${server%\'}"
+    if [ "$server" = "$BROKER1_HOST" ] && [ -z "$slot1" ]; then slot1="$n"
+    elif [ "$server" = "$BROKER2_HOST" ] && [ -z "$slot2" ]; then slot2="$n"
+    elif [ -z "$server" ]; then free+=("$n")
+    fi
+  done
+  if [ -z "$slot1" ] && [ "${#free[@]}" -gt 0 ]; then slot1="${free[0]}"; free=("${free[@]:1}"); fi
+  if [ -z "$slot2" ] && [ "${#free[@]}" -gt 0 ]; then slot2="${free[0]}"; fi
+  if [ -z "$slot1" ] || [ -z "$slot2" ]; then
+    echo "Not enough empty broker slots. Keep your existing connections, or free two slots and run again. No settings changed." >&2
+    return 1
+  fi
+  printf '%s %s\n' "$slot1" "$slot2"
 }
 
 patch_env_capture() {
-  local env_file current_iata backup n
+  local env_file current_iata backup slots slot1 slot2
   env_file="$(packetcapture_env_path)"
   install_packetcapture
   mkdir -p "$(dirname "$env_file")"
@@ -556,16 +570,15 @@ patch_env_capture() {
   fi
   require_iata
 
+  slots="$(choose_packetcapture_slots "$env_file")" || return 1
+  read -r slot1 slot2 <<< "$slots"
   backup="$(backup_path "$env_file")"
   cp -p "$env_file" "$backup"
   chmod 0600 "$backup"
 
   upsert_env "$env_file" "PACKETCAPTURE_IATA" "$IATA"
-  set_packetcapture_slot "$env_file" 1 "$BROKER1_HOST"
-  set_packetcapture_slot "$env_file" 2 "$BROKER2_HOST"
-  for n in 3 4 5 6; do
-    disable_packetcapture_slot "$env_file" "$n"
-  done
+  set_packetcapture_slot "$env_file" "$slot1" "$BROKER1_HOST"
+  set_packetcapture_slot "$env_file" "$slot2" "$BROKER2_HOST"
   chmod 0600 "$env_file"
   say "Patched: $env_file"
   say "Backup written: $backup"

--- a/docs/analyzer/scripts/add-meshcore-ca-packetcapture-broker.ps1
+++ b/docs/analyzer/scripts/add-meshcore-ca-packetcapture-broker.ps1
@@ -114,7 +114,7 @@ function Set-EnvValue {
         $lines = Get-Content $Path
     }
     $updated = $false
-    $out = foreach ($line in $lines) {
+    $out = @(foreach ($line in $lines) {
         if ($line -match "^${Key}=") {
             if (-not $updated) {
                 $updated = $true
@@ -124,7 +124,7 @@ function Set-EnvValue {
         else {
             $line
         }
-    }
+    })
     if (-not $updated) {
         $out += "${Key}=${Value}"
     }
@@ -135,16 +135,16 @@ function Set-PacketCaptureSlot {
     param(
         [string]$Path,
         [int]$Slot,
-        [string]$Host
+        [string]$BrokerHost
     )
     Set-EnvValue -Path $Path -Key "PACKETCAPTURE_MQTT${Slot}_ENABLED" -Value "true"
-    Set-EnvValue -Path $Path -Key "PACKETCAPTURE_MQTT${Slot}_SERVER" -Value $Host
+    Set-EnvValue -Path $Path -Key "PACKETCAPTURE_MQTT${Slot}_SERVER" -Value $BrokerHost
     Set-EnvValue -Path $Path -Key "PACKETCAPTURE_MQTT${Slot}_PORT" -Value $BrokerPort
     Set-EnvValue -Path $Path -Key "PACKETCAPTURE_MQTT${Slot}_TRANSPORT" -Value "websockets"
     Set-EnvValue -Path $Path -Key "PACKETCAPTURE_MQTT${Slot}_USE_TLS" -Value "true"
     Set-EnvValue -Path $Path -Key "PACKETCAPTURE_MQTT${Slot}_TLS_VERIFY" -Value "true"
     Set-EnvValue -Path $Path -Key "PACKETCAPTURE_MQTT${Slot}_USE_AUTH_TOKEN" -Value "true"
-    Set-EnvValue -Path $Path -Key "PACKETCAPTURE_MQTT${Slot}_TOKEN_AUDIENCE" -Value $Host
+    Set-EnvValue -Path $Path -Key "PACKETCAPTURE_MQTT${Slot}_TOKEN_AUDIENCE" -Value $BrokerHost
     Set-EnvValue -Path $Path -Key "PACKETCAPTURE_MQTT${Slot}_KEEPALIVE" -Value "120"
     Set-EnvValue -Path $Path -Key "PACKETCAPTURE_MQTT${Slot}_QOS" -Value "0"
     Set-EnvValue -Path $Path -Key "PACKETCAPTURE_MQTT${Slot}_RETAIN" -Value "true"
@@ -152,13 +152,29 @@ function Set-PacketCaptureSlot {
     Set-EnvValue -Path $Path -Key "PACKETCAPTURE_MQTT${Slot}_TOPIC_PACKETS" -Value "meshcore/{IATA}/{PUBLIC_KEY}/packets"
 }
 
-function Disable-PacketCaptureSlot {
-    param(
-        [string]$Path,
-        [int]$Slot
-    )
-    Set-EnvValue -Path $Path -Key "PACKETCAPTURE_MQTT${Slot}_ENABLED" -Value "false"
-    Set-EnvValue -Path $Path -Key "PACKETCAPTURE_MQTT${Slot}_SERVER" -Value ""
+function Get-PacketCaptureSlots {
+    param([string]$Path)
+    $servers = @{}
+    foreach ($line in Get-Content -LiteralPath $Path) {
+        if ($line -match '^PACKETCAPTURE_MQTT([1-6])_SERVER=(.*)$') {
+            $servers[[int]$Matches[1]] = $Matches[2].Trim().Trim('"', "'")
+        }
+    }
+    $chosen = @($null, $null)
+    for ($index = 0; $index -lt 2; $index++) {
+        $broker = @($Broker1Host, $Broker2Host)[$index]
+        $slot = 1..6 | Where-Object { $servers[$_] -eq $broker -and $_ -notin $chosen } | Select-Object -First 1
+        $chosen[$index] = $slot
+    }
+    for ($index = 0; $index -lt 2; $index++) {
+        if (-not $chosen[$index]) {
+            $chosen[$index] = 1..6 | Where-Object { [string]::IsNullOrWhiteSpace($servers[$_]) -and $_ -notin $chosen } | Select-Object -First 1
+        }
+    }
+    if (-not $chosen[0] -or -not $chosen[1]) {
+        throw 'Not enough empty broker slots. Free slots before trying again. No settings changed.'
+    }
+    return $chosen
 }
 
 function Ensure-PacketCaptureInstall {
@@ -206,15 +222,13 @@ if (-not (Test-Path $envPath)) {
     New-Item -ItemType File -Path $envPath -Force | Out-Null
 }
 
+$slots = @(Get-PacketCaptureSlots -Path $envPath)
 $backupPath = New-BackupPath -Path $envPath
 Copy-Item -Path $envPath -Destination $backupPath -Force
 
 Set-EnvValue -Path $envPath -Key "PACKETCAPTURE_IATA" -Value $Iata
-Set-PacketCaptureSlot -Path $envPath -Slot 1 -Host $Broker1Host
-Set-PacketCaptureSlot -Path $envPath -Slot 2 -Host $Broker2Host
-foreach ($slot in 3..6) {
-    Disable-PacketCaptureSlot -Path $envPath -Slot $slot
-}
+Set-PacketCaptureSlot -Path $envPath -Slot $slots[0] -BrokerHost $Broker1Host
+Set-PacketCaptureSlot -Path $envPath -Slot $slots[1] -BrokerHost $Broker2Host
 
 Write-Host ""
 Write-Info "Patched: $envPath"

--- a/docs/analyzer/verify.fr.md
+++ b/docs/analyzer/verify.fr.md
@@ -18,7 +18,7 @@ page_styles:
 
 # Vérifier votre observateur
 
-Une connexion au courtier confirme seulement l’accès Internet. Votre
+Une connexion ne confirme pas que les paquets arrivent à CoreScope. Votre
 observateur fonctionne lorsqu’un véritable paquet radio se rend jusqu’à
 CoreScope.
 

--- a/docs/analyzer/verify.md
+++ b/docs/analyzer/verify.md
@@ -18,7 +18,7 @@ page_styles:
 
 # Check your observer
 
-A broker connection proves only internet access. Your observer is working when
+Connected does not mean packets have reached CoreScope. Your observer is working when
 a real radio packet reaches CoreScope.
 
 ## Follow a packet through four stages

--- a/docs/assets/javascripts/analyzer-command-builder.js
+++ b/docs/assets/javascripts/analyzer-command-builder.js
@@ -78,7 +78,9 @@
       number: document.getElementById("observer-number"),
       ssid: document.getElementById("observer-ssid"),
       password: document.getElementById("observer-password"),
-      repeat: document.getElementById("observer-repeat")
+      repeat: document.getElementById("observer-repeat"),
+      radio: document.getElementById("observer-radio"),
+      hash: document.getElementById("observer-hash")
     };
     var output = document.getElementById("observer-command-output");
     var status = document.getElementById("observer-copy-status");
@@ -99,6 +101,8 @@
     }
 
     root.dataset.ready = "true";
+    var radioProfiles = window.MeshCoreRadioProfiles;
+    if (radioProfiles) radioProfiles.populate(fields.radio);
     var exactCommands = [];
     var commandsRevealed = false;
 
@@ -126,6 +130,8 @@
         [tr("Board", "Carte"), fields.board.options[fields.board.selectedIndex].text],
         [tr("Location", "Emplacement"), iata || tr("Not set", "Non défini")],
         [tr("Node name", "Nom du nœud"), nodeName || tr("Not set", "Non défini")],
+        [tr("Radio network", "Réseau radio"), radioProfiles ? radioProfiles.label(fields.radio.value) : tr("Keep current settings", "Conserver les réglages actuels")],
+        [tr("Advert ID size", "Taille de l’identifiant d’annonce"), fields.hash.options[fields.hash.selectedIndex].text],
         [
           tr("Mesh traffic", "Trafic du réseau maillé"),
           repeat === "on"
@@ -218,18 +224,13 @@
 
       exactCommands = [
         "set name " + nodeName,
-        "set radio 910.525,62.5,7,5",
-        "set path.hash.mode 2",
+      ].concat(radioProfiles ? radioProfiles.commands(fields.radio.value, fields.hash.value) : [], [
         "set mqtt.iata " + iata,
         "set wifi.ssid " + ssid,
         "set wifi.pwd " + password,
         "set wifi.powersave none",
         "set mqtt1.preset meshcore-ca-1",
         "set mqtt2.preset meshcore-ca-2",
-        "set mqtt3.preset none",
-        "set mqtt4.preset none",
-        "set mqtt5.preset none",
-        "set mqtt6.preset none",
         "set mqtt.status on",
         "set mqtt.packets on",
         "set mqtt.raw off",
@@ -239,7 +240,7 @@
         "set repeat " + repeat,
         "advert",
         "reboot"
-      ];
+      ]);
       revealCommandsButton.disabled = false;
       showCurrentCommands();
     }

--- a/docs/assets/javascripts/radio-profiles.js
+++ b/docs/assets/javascripts/radio-profiles.js
@@ -1,0 +1,50 @@
+(function () {
+  "use strict";
+  var source = new URL("../radio-profiles.json", document.currentScript.src);
+  var french = /^fr(?:-|$)/i.test(document.documentElement.lang);
+  var profiles = [];
+  var loading;
+
+  function commands(id, hashMode) {
+    var result = [];
+    if (id && id !== "keep") {
+      var profile = profiles.find(function (item) { return item.id === id; });
+      if (!profile) throw new Error("Unknown radio profile");
+      var radio = profile.radio;
+      result.push("set radio " + [radio.frequency_mhz, radio.bandwidth_khz, radio.spreading_factor, radio.coding_rate].join(","));
+    }
+    if (["0", "1", "2"].indexOf(hashMode) !== -1) result.push("set path.hash.mode " + hashMode);
+    return result;
+  }
+
+  function populate(select) {
+    if (!loading) loading = fetch(source).then(function (response) {
+      if (!response.ok) throw new Error("Radio profiles unavailable");
+      return response.json();
+    }).then(function (data) { profiles = data; });
+    return loading.then(function () {
+      profiles.forEach(function (profile) {
+        var option = document.createElement("option");
+        option.value = profile.id;
+        option.textContent = (french ? profile.name_fr : profile.name) + " · " +
+          profile.radio.frequency_mhz + " MHz";
+        select.appendChild(option);
+      });
+    }).catch(function () {
+      // Keep-current remains usable; never substitute a default when data fails.
+      var notice = document.createElement("p");
+      notice.setAttribute("role", "status");
+      notice.textContent = french
+        ? "Profils radio indisponibles. Les réglages actuels seront conservés."
+        : "Radio profiles unavailable. Current settings will be kept.";
+      select.after(notice);
+    });
+  }
+
+  function label(id) {
+    var profile = profiles.find(function (item) { return item.id === id; });
+    return profile ? (french ? profile.name_fr : profile.name) + " · " + profile.radio.frequency_mhz + " MHz"
+      : (french ? "Conserver les réglages actuels" : "Keep current settings");
+  }
+  window.MeshCoreRadioProfiles = { commands: commands, populate: populate, label: label };
+}());

--- a/docs/assets/javascripts/repeater-hash-check.js
+++ b/docs/assets/javascripts/repeater-hash-check.js
@@ -315,7 +315,7 @@
     var rows = summaries.map(function (summary) {
       var selected = summary.bytes === selectedBytes;
       return '<tr' + (selected ? ' class="is-selected"' : '') + '>' +
-        '<td data-label="' + escapeHtml(message(language, "modeColumn")) + '"><strong>' + summary.bytes + '</strong> ' +
+        '<td data-label="' + escapeHtml(message(language, "modeColumn")) + '">' +
           escapeHtml(summary.bytes === 1 ? message(language, "oneByte") : message(language, summary.bytes === 2 ? "twoBytes" : "threeBytes")) +
           (selected ? ' <span class="mc-hash-selected">' + escapeHtml(message(language, "selected")) + '</span>' : '') + '</td>' +
         '<td data-label="' + escapeHtml(message(language, "idColumn")) + '"><code>' + escapeHtml(summary.prefix) + '</code></td>' +

--- a/docs/assets/radio-profiles.json
+++ b/docs/assets/radio-profiles.json
@@ -1,0 +1,27 @@
+[
+  {
+    "id": "canada",
+    "name": "Canada default",
+    "name_fr": "Réglages canadiens par défaut",
+    "radio": {
+      "frequency_mhz": 910.525,
+      "bandwidth_khz": 62.5,
+      "spreading_factor": 7,
+      "coding_rate": 5
+    },
+    "route": "provinces/#canada-baseline"
+  },
+  {
+    "id": "bc-mesh",
+    "name": "BC Mesh",
+    "name_fr": "BC Mesh",
+    "radio": {
+      "frequency_mhz": 910.425,
+      "bandwidth_khz": 62.5,
+      "spreading_factor": 7,
+      "coding_rate": 5
+    },
+    "route": "provinces/british-columbia/#community-bc-mesh",
+    "reviewed": "2026-08-29"
+  }
+]

--- a/docs/assets/regions/modules/configurator-support.js
+++ b/docs/assets/regions/modules/configurator-support.js
@@ -25,12 +25,14 @@
     var paths = Array.isArray(input.paths) ? input.paths.map(normalizeText).filter(Boolean) : [];
     var commands = Array.isArray(input.commands) ? input.commands.map(normalizeText).filter(Boolean) : [];
     var lines = [
-      "MeshCore Canada repeater commissioning summary",
+      "MeshCore Canada repeater setup summary",
       "Generated: " + normalizeText(input.generatedAt),
       "Location label: " + (normalizeText(input.locationLabel) || "Not recorded"),
       "Home region: " + normalizeText(input.homeRegion),
       "Firmware: " + normalizeText(input.firmware),
       "Region budget: " + normalizeText(input.budget),
+      "Radio network: " + normalizeText(input.radio || "Keep current settings"),
+      "Advert ID size: " + normalizeText(input.hashMode || "Keep current settings"),
       "",
       "Forwarding paths:"
     ];
@@ -43,6 +45,8 @@
       "1. Run region before saving and compare every path above.",
       "2. Run region save only after the paths and flood permissions are correct.",
       "3. Run region again after saving.",
+      "4. If radio settings changed, reboot and run get radio to confirm them.",
+      "5. If the advert ID size changed, run get path.hash.mode to confirm it.",
       "",
       "This summary omits exact coordinates, passwords, private keys, and device identifiers."
     );

--- a/docs/assets/regions/regions.css
+++ b/docs/assets/regions/regions.css
@@ -2,6 +2,14 @@ body:has([data-mcc-regions="map"]) [data-mcc-regions="map"] {
   margin: 0;
 }
 
+/* Reserve space before any scripts run, without adding a gap for no-JavaScript readers. */
+@media (scripting: enabled) {
+  [data-mcc-regions="map"]:empty,
+  [data-mcc-regions="map"][data-mcc-loading="1"] {
+    min-height: 60rem;
+  }
+}
+
 body:has([data-mcc-regions]) {
   background: var(--md-default-bg-color, #ffffff);
 }
@@ -23,10 +31,6 @@ body:has([data-mcc-regions]) .md-typeset h1,
 body:has([data-mcc-regions]) .md-typeset h2,
 body:has([data-mcc-regions]) .md-typeset h3 {
   color: var(--md-default-fg-color);
-}
-
-body:has([data-mcc-regions]) .md-main .md-typeset a {
-  color: var(--md-typeset-a-color, #5488e8);
 }
 
 .mcc-visually-hidden {
@@ -264,7 +268,8 @@ body:has([data-mcc-regions]) .md-main .md-typeset a {
   outline: 0.12rem solid color-mix(in srgb, var(--mcc-green), transparent 76%);
 }
 
-.mcc-button {
+.mcc-button,
+.md-typeset a.mcc-button {
   display: inline-flex;
   gap: 0.35rem;
   align-items: center;
@@ -288,7 +293,9 @@ body:has([data-mcc-regions]) .md-main .md-typeset a {
 }
 
 .mcc-button:hover,
-.mcc-button:focus {
+.mcc-button:focus,
+.md-typeset a.mcc-button:hover,
+.md-typeset a.mcc-button:focus {
   color: var(--mcc-action-text);
   background: var(--mcc-green-dark);
   border-color: var(--mcc-green-dark);
@@ -299,14 +306,17 @@ body:has([data-mcc-regions]) .md-main .md-typeset a {
   cursor: not-allowed;
 }
 
-.mcc-button-secondary {
+.mcc-button-secondary,
+.md-typeset a.mcc-button-secondary {
   color: var(--mcc-text);
   background: transparent;
   border-color: var(--mcc-border);
 }
 
 .mcc-button-secondary:hover,
-.mcc-button-secondary:focus {
+.mcc-button-secondary:focus,
+.md-typeset a.mcc-button-secondary:hover,
+.md-typeset a.mcc-button-secondary:focus {
   color: var(--mcc-text);
   background: var(--mcc-soft);
   border-color: var(--mcc-green);
@@ -855,7 +865,7 @@ body:has([data-mcc-regions]) .md-main .md-typeset a {
 .mcc-map-shell {
   display: grid;
   grid-template-columns: minmax(23rem, 27.5rem) minmax(0, 1fr);
-  height: clamp(30rem, calc(100vh - 8rem), 40rem);
+  height: auto;
   min-height: 30rem;
   border: 1px solid var(--mcc-border);
   border-radius: 0.45rem;
@@ -916,7 +926,7 @@ body:has([data-mcc-regions]) .md-main .md-typeset a {
   gap: 0.75rem;
   padding: 1rem;
   background: var(--mcc-panel);
-  overflow: auto;
+  overflow: visible;
 }
 
 .mcc-map-stage {
@@ -925,7 +935,7 @@ body:has([data-mcc-regions]) .md-main .md-typeset a {
   min-height: 30rem;
 }
 
-.mcc-skip-map {
+.md-typeset .mcc-skip-map {
   position: absolute;
   top: 0.5rem;
   left: 0.5rem;
@@ -934,11 +944,15 @@ body:has([data-mcc-regions]) .md-main .md-typeset a {
   border-radius: 0.3rem;
   color: var(--mcc-action-text);
   background: var(--mcc-green-dark);
-  transform: translateY(calc(-100% - 1rem));
+  clip-path: inset(50%);
+  opacity: 0;
+  pointer-events: none;
 }
 
-.mcc-skip-map:focus {
-  transform: none;
+.md-typeset .mcc-skip-map:focus {
+  clip-path: none;
+  opacity: 1;
+  pointer-events: auto;
 }
 
 .mcc-map-loading {
@@ -1103,9 +1117,9 @@ body:has([data-mcc-regions]) .md-main .md-typeset a {
 
 .mcc-map-canvas .leaflet-bar a,
 .mcc-map-canvas .leaflet-bar a:hover {
-  border-color: rgba(133, 179, 174, 0.24);
-  color: var(--mc-color-text);
-  background: rgba(11, 20, 27, 0.92);
+  border-color: var(--mcc-border);
+  color: var(--mcc-text);
+  background: var(--mcc-surface);
 }
 
 .mcc-region-borders {

--- a/docs/assets/regions/regions.css
+++ b/docs/assets/regions/regions.css
@@ -970,6 +970,19 @@ body:has([data-mcc-regions]) .md-typeset h3 {
   text-align: center;
 }
 
+.md-typeset .mcc-map-progress {
+  position: absolute;
+  top: 0.5rem;
+  left: 3rem;
+  z-index: 1001;
+  margin: 0;
+  padding: 0.3rem 0.5rem;
+  border-radius: 0.3rem;
+  color: var(--mcc-text);
+  background: var(--mcc-surface);
+  font-size: 0.8rem;
+}
+
 .mcc-map-loading > div {
   display: grid;
   max-width: 28rem;

--- a/docs/assets/regions/regions.css
+++ b/docs/assets/regions/regions.css
@@ -6,15 +6,13 @@ body:has([data-mcc-regions]) {
   background: var(--md-default-bg-color, #ffffff);
 }
 
-/* Region tools use one deliberate dark workbench in either site palette. This
-   keeps dense maps, command output, and status colours readable after a theme
-   switch while the header, navigation, and surrounding site still follow it. */
+/* Use the site's palette for the workbench as well as its surrounding navigation. */
 body:has([data-mcc-regions]) .md-main,
 body:has([data-mcc-regions]) .md-main__inner,
 body:has([data-mcc-regions]) .md-content,
 body:has([data-mcc-regions]) .md-content__inner {
-  color: #dce9e7;
-  background: #0c151c;
+  color: var(--md-default-fg-color);
+  background: var(--md-default-bg-color);
 }
 
 body:has([data-mcc-regions="map"]) .md-main__inner {
@@ -24,7 +22,7 @@ body:has([data-mcc-regions="map"]) .md-main__inner {
 body:has([data-mcc-regions]) .md-typeset h1,
 body:has([data-mcc-regions]) .md-typeset h2,
 body:has([data-mcc-regions]) .md-typeset h3 {
-  color: #ffffff;
+  color: var(--md-default-fg-color);
 }
 
 body:has([data-mcc-regions]) .md-main .md-typeset a {
@@ -49,7 +47,7 @@ body:has([data-mcc-regions]) .md-main .md-typeset a {
   border: 1px solid rgba(133, 179, 174, 0.24);
   border-left: 0.22rem solid #2f7d68;
   border-radius: 0.35rem;
-  color: #eaf3f1;
+  color: var(--mc-color-text);
   background: rgba(88, 184, 137, 0.1);
 }
 
@@ -65,9 +63,9 @@ body:has([data-mcc-regions]) .md-main .md-typeset a {
   padding: 0.85rem 0.95rem;
   border: 1px solid rgba(133, 179, 174, 0.24);
   border-radius: 0.35rem;
-  color: #eaf3f1;
+  color: var(--mc-color-text);
   text-decoration: none;
-  background: #101d26;
+  background: var(--mcc-surface);
 }
 
 .mcc-region-action:hover {
@@ -92,15 +90,20 @@ body:has([data-mcc-regions]) .md-main .md-typeset a {
   --mcc-blue: #303fa1;
   --mcc-gold: #f4bf5a;
   --mcc-red: #ff7373;
-  --mcc-border: rgba(159, 216, 189, 0.22);
+  --mcc-border: var(--mc-color-border);
   --mcc-soft: rgba(66, 135, 255, 0.15);
-  --mcc-panel: #0c151c;
-  --mcc-surface: #101d26;
-  --mcc-surface-2: #172630;
-  --mcc-text: #dce9e7;
-  --mcc-muted: #a7b9bb;
+  --mcc-panel: var(--md-default-bg-color);
+  --mcc-surface: var(--mc-color-surface);
+  --mcc-surface-2: var(--mc-color-surface-raised);
+  --mcc-text: var(--md-default-fg-color);
+  --mcc-muted: var(--mc-color-text-muted);
+  --mcc-action-text: #fff;
   margin: 1rem 0 2rem;
   color: var(--mcc-text);
+}
+
+[data-md-color-scheme="slate"] [data-mcc-regions] {
+  --mcc-action-text: #101827;
 }
 
 /* Match the first configurator step before its progressive enhancement mounts. */
@@ -137,14 +140,14 @@ body:has([data-mcc-regions]) .md-main .md-typeset a {
   padding: 0.35rem 0 0.25rem;
   border: 0;
   border-radius: 0;
-  color: #ffffff;
+  color: var(--mcc-text);
   background: transparent;
 }
 
 .mcc-console-header h1,
 .mcc-console-header h2 {
   margin: 0;
-  color: #ffffff;
+  color: var(--mcc-text);
   font-size: clamp(1.25rem, 2.1vw, 1.65rem);
   letter-spacing: 0;
 }
@@ -286,6 +289,7 @@ body:has([data-mcc-regions]) .md-main .md-typeset a {
 
 .mcc-button:hover,
 .mcc-button:focus {
+  color: var(--mcc-action-text);
   background: var(--mcc-green-dark);
   border-color: var(--mcc-green-dark);
 }
@@ -303,7 +307,7 @@ body:has([data-mcc-regions]) .md-main .md-typeset a {
 
 .mcc-button-secondary:hover,
 .mcc-button-secondary:focus {
-  color: #ffffff;
+  color: var(--mcc-text);
   background: var(--mcc-soft);
   border-color: var(--mcc-green);
 }
@@ -462,7 +466,7 @@ body:has([data-mcc-regions]) .md-main .md-typeset a {
 }
 
 .mcc-status-warning {
-  color: #f6dda8;
+  color: var(--mc-color-warning);
   background: color-mix(in srgb, var(--mcc-gold), transparent 82%);
 }
 
@@ -487,7 +491,7 @@ body:has([data-mcc-regions]) .md-main .md-typeset a {
   border: 1px solid var(--mcc-border);
   border-radius: 0.35rem;
   color: var(--mcc-text);
-  background: #09131a;
+  background: var(--mcc-surface);
   text-align: left;
   cursor: pointer;
 }
@@ -574,7 +578,7 @@ body:has([data-mcc-regions]) .md-main .md-typeset a {
 }
 
 .mcc-empty-state strong {
-  color: #ffffff;
+  color: var(--mcc-text);
   font-size: 1rem;
 }
 
@@ -706,7 +710,7 @@ body:has([data-mcc-regions]) .md-main .md-typeset a {
   min-width: 0;
   margin: 0.12rem 0 0;
   overflow: hidden;
-  color: #eaf3f1;
+  color: var(--mc-color-text);
   font-size: 0.78rem;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -928,7 +932,7 @@ body:has([data-mcc-regions]) .md-main .md-typeset a {
   z-index: 1001;
   padding: 0.45rem 0.65rem;
   border-radius: 0.3rem;
-  color: #ffffff;
+  color: var(--mcc-action-text);
   background: var(--mcc-green-dark);
   transform: translateY(calc(-100% - 1rem));
 }
@@ -990,7 +994,7 @@ body:has([data-mcc-regions]) .md-main .md-typeset a {
 
 .mcc-region-crumb:hover,
 .mcc-region-crumb:focus-visible {
-  color: #ffffff;
+  color: var(--mcc-text);
   text-decoration: underline;
 }
 
@@ -1044,7 +1048,7 @@ body:has([data-mcc-regions]) .md-main .md-typeset a {
   padding: 0 0 0.2rem;
   border: 0;
   border-radius: 0;
-  color: #ffffff;
+  color: var(--mcc-text);
   background: transparent;
 }
 
@@ -1066,7 +1070,7 @@ body:has([data-mcc-regions]) .md-main .md-typeset a {
 .mcc-panel-header h1,
 .mcc-panel-header h2 {
   margin: 0;
-  color: #ffffff;
+  color: var(--mcc-text);
   font-size: 1.28rem;
   letter-spacing: 0;
 }
@@ -1100,7 +1104,7 @@ body:has([data-mcc-regions]) .md-main .md-typeset a {
 .mcc-map-canvas .leaflet-bar a,
 .mcc-map-canvas .leaflet-bar a:hover {
   border-color: rgba(133, 179, 174, 0.24);
-  color: #eaf3f1;
+  color: var(--mc-color-text);
   background: rgba(11, 20, 27, 0.92);
 }
 
@@ -1145,7 +1149,7 @@ body:has([data-mcc-regions]) .md-main .md-typeset a {
   padding: 0.9rem;
   border: 1px solid rgba(159, 216, 189, 0.24);
   border-radius: 0.45rem;
-  color: #eaf3f1;
+  color: var(--mc-color-text);
   background: rgba(7, 16, 22, 0.92);
   box-shadow: 0 18px 42px rgba(0, 0, 0, 0.34);
 }
@@ -1238,7 +1242,7 @@ body:has([data-mcc-regions]) .md-main .md-typeset a {
 }
 
 .mcc-detail-node code {
-  color: #ffffff;
+  color: var(--mcc-text);
   font-size: 0.82rem;
 }
 
@@ -1364,7 +1368,7 @@ body:has([data-mcc-regions]) .md-main .md-typeset a {
 }
 
 .mcc-visible-legend-head strong {
-  color: #eaf3f1;
+  color: var(--mc-color-text);
   font-size: 0.76rem;
 }
 
@@ -1416,7 +1420,7 @@ body:has([data-mcc-regions]) .md-main .md-typeset a {
 .mcc-visible-region strong {
   display: block;
   overflow: hidden;
-  color: #eaf3f1;
+  color: var(--mc-color-text);
   font-size: 0.72rem;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -1507,7 +1511,7 @@ body:has([data-mcc-regions]) .md-main .md-typeset a {
   padding: 0.62rem 0.7rem;
   border: 1px solid rgba(159, 216, 189, 0.18);
   border-radius: 0.35rem;
-  color: #eaf3f1;
+  color: var(--mc-color-text);
   background: var(--mcc-surface);
   text-decoration: none;
 }
@@ -1515,7 +1519,7 @@ body:has([data-mcc-regions]) .md-main .md-typeset a {
 .mcc-action-button:hover,
 .mcc-action-button:focus {
   border-color: rgba(159, 216, 189, 0.42);
-  color: #ffffff;
+  color: var(--mcc-text);
   background: rgba(88, 184, 137, 0.11);
   text-decoration: none;
 }
@@ -1572,7 +1576,7 @@ body:has([data-mcc-regions]) .md-main .md-typeset a {
 .mcc-stat strong {
   display: block;
   margin-top: 0.18rem;
-  color: #ffffff;
+  color: var(--mcc-text);
   font-size: 1.45rem;
   line-height: 1;
 }
@@ -1593,7 +1597,7 @@ body:has([data-mcc-regions]) .md-main .md-typeset a {
   display: flex;
   gap: 0.36rem;
   align-items: center;
-  color: #ffffff;
+  color: var(--mcc-text);
   font-size: 0.86rem;
 }
 
@@ -1717,8 +1721,8 @@ body:has([data-mcc-regions]) .md-main .md-typeset a {
 }
 
 .mcc-region-table td {
-  color: #eaf3f1;
-  background: #101d26;
+  color: var(--mc-color-text);
+  background: var(--mcc-surface);
   font-size: 0.76rem;
 }
 
@@ -1951,7 +1955,7 @@ ol.mcc-wizard-progress > li {
 }
 
 .mcc-finish-path strong {
-  color: #ffffff;
+  color: var(--mcc-text);
 }
 
 .mcc-finish-path small {
@@ -2011,7 +2015,7 @@ ol.mcc-guide-steps > li::before {
 
 .mcc-guide-steps h4 {
   margin: 0;
-  color: #ffffff;
+  color: var(--mcc-text);
   font-size: 0.92rem;
 }
 
@@ -2056,7 +2060,7 @@ ol.mcc-guide-steps > li::before {
 
 .mcc-connect-method h5 {
   margin: 0;
-  color: #ffffff;
+  color: var(--mcc-text);
   font-size: 0.84rem;
 }
 

--- a/docs/assets/regions/regions.js
+++ b/docs/assets/regions/regions.js
@@ -9,9 +9,7 @@
   var displayPartitionPromise = null;
   var resolverPartitionPromise = null;
   var leafletPromise = null;
-  var lucidePromise = null;
   var activeMaps = [];
-  var LUCIDE_SRC = new URL("vendor/lucide.js", assetBase).href;
   var configuratorSupport = window.MeshCoreRegionConfiguratorSupport || {};
   var radioProfiles = window.MeshCoreRadioProfiles;
   var REQUEST_TIMEOUT_MS = 12000;
@@ -20,6 +18,7 @@
   );
 
   var FRENCH_RUNTIME_TEXT = {
+    "Loading regional boundaries…": "Chargement des limites régionales…",
     "Radio network": "Réseau radio",
     "Advert ID size": "Taille de l’identifiant d’annonce",
     "Keep current settings": "Conserver les réglages actuels",
@@ -737,40 +736,30 @@
       .replace(/"/g, "&quot;");
   }
 
+  // Lucide 0.547.0 SVG paths; ISC/Feather MIT notices are in vendor/lucide-LICENSE.
+  // Include only the 17 icons used here, without downloading the full icon library.
+  var ICONS = {
+    "arrow-left": "<path d=\"m12 19-7-7 7-7\" /><path d=\"M19 12H5\" />",
+    "arrow-right": "<path d=\"M5 12h14\" /><path d=\"m12 5 7 7-7 7\" />",
+    "book-open-check": "<path d=\"M12 21V7\" /><path d=\"m16 12 2 2 4-4\" /><path d=\"M22 6V4a1 1 0 0 0-1-1h-5a4 4 0 0 0-4 4 4 4 0 0 0-4-4H3a1 1 0 0 0-1 1v13a1 1 0 0 0 1 1h6a3 3 0 0 1 3 3 3 3 0 0 1 3-3h6a1 1 0 0 0 1-1v-1.3\" />",
+    "clipboard": "<rect width=\"8\" height=\"4\" x=\"8\" y=\"2\" rx=\"1\" ry=\"1\" /><path d=\"M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2\" />",
+    "copy": "<rect width=\"14\" height=\"14\" x=\"8\" y=\"8\" rx=\"2\" ry=\"2\" /><path d=\"M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2\" />",
+    "download": "<path d=\"M12 15V3\" /><path d=\"M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4\" /><path d=\"m7 10 5 5 5-5\" />",
+    "external-link": "<path d=\"M15 3h6v6\" /><path d=\"M10 14 21 3\" /><path d=\"M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6\" />",
+    "link": "<path d=\"M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71\" /><path d=\"M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71\" />",
+    "list-checks": "<path d=\"M13 5h8\" /><path d=\"M13 12h8\" /><path d=\"M13 19h8\" /><path d=\"m3 17 2 2 4-4\" /><path d=\"m3 7 2 2 4-4\" />",
+    "locate-fixed": "<line x1=\"2\" x2=\"5\" y1=\"12\" y2=\"12\" /><line x1=\"19\" x2=\"22\" y1=\"12\" y2=\"12\" /><line x1=\"12\" x2=\"12\" y1=\"2\" y2=\"5\" /><line x1=\"12\" x2=\"12\" y1=\"19\" y2=\"22\" /><circle cx=\"12\" cy=\"12\" r=\"7\" /><circle cx=\"12\" cy=\"12\" r=\"3\" />",
+    "map": "<path d=\"M14.106 5.553a2 2 0 0 0 1.788 0l3.659-1.83A1 1 0 0 1 21 4.619v12.764a1 1 0 0 1-.553.894l-4.553 2.277a2 2 0 0 1-1.788 0l-4.212-2.106a2 2 0 0 0-1.788 0l-3.659 1.83A1 1 0 0 1 3 19.381V6.618a1 1 0 0 1 .553-.894l4.553-2.277a2 2 0 0 1 1.788 0z\" /><path d=\"M15 5.764v15\" /><path d=\"M9 3.236v15\" />",
+    "printer": "<path d=\"M6 18H4a2 2 0 0 1-2-2v-5a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2h-2\" /><path d=\"M6 9V3a1 1 0 0 1 1-1h10a1 1 0 0 1 1 1v6\" /><rect x=\"6\" y=\"14\" width=\"12\" height=\"8\" rx=\"1\" />",
+    "radio-tower": "<path d=\"M4.9 16.1C1 12.2 1 5.8 4.9 1.9\" /><path d=\"M7.8 4.7a6.14 6.14 0 0 0-.8 7.5\" /><circle cx=\"12\" cy=\"9\" r=\"2\" /><path d=\"M16.2 4.8c2 2 2.26 5.11.8 7.47\" /><path d=\"M19.1 1.9a9.96 9.96 0 0 1 0 14.1\" /><path d=\"M9.5 18h5\" /><path d=\"m8 22 4-11 4 11\" />",
+    "search": "<path d=\"m21 21-4.34-4.34\" /><circle cx=\"11\" cy=\"11\" r=\"8\" />",
+    "terminal": "<path d=\"M12 19h8\" /><path d=\"m4 17 6-6-6-6\" />",
+    "triangle-alert": "<path d=\"m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3\" /><path d=\"M12 9v4\" /><path d=\"M12 17h.01\" />",
+    "usb": "<circle cx=\"10\" cy=\"7\" r=\"1\" /><circle cx=\"4\" cy=\"20\" r=\"1\" /><path d=\"M4.7 19.3 19 5\" /><path d=\"m21 3-3 1 2 2Z\" /><path d=\"M9.26 7.68 5 12l2 5\" /><path d=\"m10 14 5 2 3.5-3.5\" /><path d=\"m18 12 1-1 1 1-1 1Z\" />"
+  };
+
   function icon(name) {
-    return '<i class="mcc-icon" data-lucide="' + esc(name) + '" aria-hidden="true"></i>';
-  }
-
-  function loadLucide() {
-    if (window.lucide && typeof window.lucide.createIcons === "function") {
-      return Promise.resolve(window.lucide);
-    }
-    if (lucidePromise) return lucidePromise;
-    lucidePromise = new Promise(function (resolve) {
-      var script = document.createElement("script");
-      script.src = LUCIDE_SRC;
-      script.defer = true;
-      script.onload = function () { resolve(window.lucide || null); };
-      script.onerror = function () { resolve(null); };
-      document.head.appendChild(script);
-    });
-    return lucidePromise;
-  }
-
-  function refreshIcons(root) {
-    loadLucide().then(function (lucide) {
-      if (!lucide || typeof lucide.createIcons !== "function") return;
-      try {
-        lucide.createIcons({
-          attrs: {
-            "stroke-width": 2,
-            "aria-hidden": "true"
-          }
-        });
-      } catch (err) {
-        // Icons are progressive enhancement; text labels remain usable.
-      }
-    });
+    return '<svg class="mcc-icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">' + (ICONS[name] || "") + '</svg>';
   }
 
   function copyText(text, button, resetLabel) {
@@ -791,7 +780,6 @@
       window.setTimeout(function () {
         button.classList.remove("is-copied");
         button.innerHTML = button.dataset.originalHtml || resetLabel || "Copy";
-        refreshIcons(button);
       }, 1400);
     };
     var fallback = function () {
@@ -1660,14 +1648,12 @@
         '<strong>No region yet</strong>' +
         '<span>Choose a location first.</span>' +
         '</div>';
-      refreshIcons(target);
       return;
     }
 
     var rec = recommend(data, state.resolution, state.type, state.selectedMetros, state.selectedExternalPaths);
     if (!rec) {
       target.innerHTML = '<div class="mcc-empty-state">' + icon("radio-tower") + '<strong>No region yet</strong></div>';
-      refreshIcons(target);
       return;
     }
     if (rec.budget.tagCount > 32 || rec.budget.responseBytes > 172) {
@@ -1676,7 +1662,6 @@
         '<strong>Too many regions selected</strong>' +
         '<span>This selection uses ' + esc(rec.budget.tagCount) + ' tags and ' + esc(rec.budget.responseBytes) + ' bytes. Remove regions until it fits the 32-tag and 172-byte limits.</span>' +
         '</div>';
-      refreshIcons(target);
       return;
     }
     var firmware = state.firmware || data.meta.defaultFirmware || "1.16";
@@ -1826,7 +1811,6 @@
         printCommissioningSummary(data, state, printSummary);
       });
     }
-    refreshIcons(target);
   }
 
   function seedForTag(data, tag) {
@@ -1988,7 +1972,6 @@
         copyText(commands.join("\n"), copyCommands, "Copy commands");
       });
     }
-    refreshIcons(target);
   }
 
   function refreshTool(data, els, state, afterRefresh) {
@@ -2126,7 +2109,6 @@
 
   function initConfig(el, data) {
     el.innerHTML = toolUi();
-    refreshIcons(el);
     var state = {
       lat: null,
       lon: null,
@@ -2243,7 +2225,6 @@
         }
       }
       updateMapLinks();
-      refreshIcons(el);
     }
 
     function selectFinishPath(path) {
@@ -2404,7 +2385,6 @@
         if (activeGeocodeController !== thisController) return;
         els.locate.disabled = false;
         els.locate.innerHTML = icon("search") + "Find";
-        refreshIcons(els.locate);
       });
     }
 
@@ -2618,6 +2598,7 @@
       '<div class="mcc-map-stage">' +
       '<a class="mcc-skip-map" href="#mcc-region-list">Skip the interactive map</a>' +
       '<div class="mcc-visually-hidden" data-role="map-ready-status" role="status" aria-live="polite" aria-atomic="true"></div>' +
+      '<p class="mcc-map-progress" data-role="map-boundary-status" role="status" hidden>Loading regional boundaries…</p>' +
       '<div class="mcc-map-loading" data-role="map-loading">' +
       '<div>' + icon("map") + '<h3>Loading interactive map…</h3>' +
       '<p data-role="map-load-status" role="status" aria-live="polite">Loading Canadian boundaries and OpenStreetMap tiles.</p>' +
@@ -2640,7 +2621,6 @@
       '<div data-role="audit-content"></div>' +
       '</section>' +
       '</div>';
-    refreshIcons(el);
 
     var mapParams = new URLSearchParams(window.location.search);
     var requestedLargeCoverage = mapParams.get("type") === "large";
@@ -2688,6 +2668,7 @@
       mapLoading: el.querySelector("[data-role='map-loading']"),
       mapLoadStatus: el.querySelector("[data-role='map-load-status']"),
       mapReadyStatus: el.querySelector("[data-role='map-ready-status']"),
+      boundaryStatus: el.querySelector("[data-role='map-boundary-status']"),
       mapArea: el.querySelector("[data-role='map-area']"),
       canvas: el.querySelector("[data-role='map-canvas']"),
       auditStatus: el.querySelector("[data-role='audit-status']"),
@@ -2753,7 +2734,6 @@
           '<a class="mcc-button mcc-button-secondary" href="' + esc(new URL("canada-regions.json", assetBase).href) + '" download>Download catalog</a>' +
           '<a class="mcc-button mcc-button-secondary" href="' + esc(regionPageHref("standard")) + '">Open standard and change process</a>' +
           '</div></section>';
-        refreshIcons(els.auditContent);
         auditLoaded = true;
       }).catch(function (error) {
         els.auditStatus.hidden = false;
@@ -2855,7 +2835,6 @@
       if (copyLink) copyLink.addEventListener("click", function () {
         copyText(mapHrefForState(state), copyLink, "Copy link");
       });
-      refreshIcons(els.textResult);
     }
 
     function finishGeo(geo, forcedTag, recenter, requestId) {
@@ -2928,7 +2907,6 @@
           if (activeGeocodeController !== thisController) return;
           els.locate.disabled = false;
           els.locate.innerHTML = icon("search") + "Find";
-          refreshIcons(els.locate);
         });
     }
 
@@ -2953,34 +2931,47 @@
       mapIsLoading = true;
       els.loadMap.hidden = true;
       els.mapStage.setAttribute("aria-busy", "true");
+      els.boundaryStatus.hidden = false;
       els.mapLoadStatus.textContent = "Loading Canadian boundaries and map tools…";
       els.mapReadyStatus.textContent = "Loading the interactive region map.";
-      Promise.all([loadDisplayPartition(), loadLeaflet()]).then(function (loaded) {
-        applyGeneratedPartition(data, loaded[0], null);
-        var L = loaded[1];
+      loadLeaflet().then(function (L) {
         L.Icon.Default.imagePath = new URL("vendor/leaflet/images/", assetBase).href;
         els.mapArea.hidden = false;
         map = L.map(els.canvas, { minZoom: 3, maxZoom: 13 });
+        var loadingMap = map;
         activeMaps.push({ container: el, map: map });
-        map.fitBounds(data.meta.map.bounds || [[41.5, -141.5], [83.5, -52]], { padding: [24, 24], maxZoom: 4 });
+        var initialRec = state.canGenerate && recommend(data, state.resolution, state.type, state.selectedMetros, state.selectedExternalPaths);
+        var initialFeatures = initialRec && data.resolverByTag
+          ? initialRec.leaves.map(function (tag) { return data.resolverByTag[tag]; }).filter(Boolean) : [];
+        var initialBounds = initialFeatures.length ? L.geoJSON(initialFeatures).getBounds() : null;
+        map.fitBounds(initialBounds && initialBounds.isValid() ? initialBounds : data.meta.map.bounds || [[41.5, -141.5], [83.5, -52]],
+          { padding: [28, 28], maxZoom: initialFeatures.length ? 9 : 4, animate: false });
         var tileLayer = L.tileLayer("https://tile.openstreetmap.org/{z}/{x}/{y}.png", {
           maxZoom: 19,
           attribution: '&copy; <a href="https://www.openstreetmap.org/copyright" rel="noopener noreferrer">OpenStreetMap</a> contributors'
         }).addTo(map);
-        L.geoJSON(data.partitionRegions, {
-          style: function (feature) {
-            return { color: "#aeb8ff", opacity: 0.8, weight: 1, fillColor: colorForTag(feature.properties.tag), fillOpacity: 0.2 };
-          },
-          onEachFeature: function (feature, layer) {
-            layer.bindTooltip('<strong>' + esc(feature.properties.tag.toUpperCase()) + '</strong> - ' + esc(feature.properties.label));
-            layer.on("click", function (event) {
-              if (event.originalEvent) L.DomEvent.stopPropagation(event.originalEvent);
-              useGeo({ lat: event.latlng.lat, lon: event.latlng.lng, name: feature.properties.label, countryCode: "ca", tag: feature.properties.tag }, false, feature.properties.tag);
-            });
-          }
-        }).addTo(map);
         browseLayer = L.geoJSON(null, { interactive: false, style: { color: "#ffd166", opacity: 1, weight: 3, fillOpacity: 0 } }).addTo(map);
         selectedLayer = L.geoJSON(null, { interactive: false, style: { color: "#ffffff", opacity: 1, weight: 4, dashArray: "8 5", fillColor: "#4287ff", fillOpacity: 0.34 } }).addTo(map);
+        updateMapVisuals(false);
+        // Paint tiles first; the much larger boundary overlay can arrive independently.
+        var boundariesReady = loadDisplayPartition().then(function (partition) {
+          if (map !== loadingMap) return;
+          applyGeneratedPartition(data, partition, null);
+          L.geoJSON(data.partitionRegions, {
+            style: function (feature) {
+              return { color: "#aeb8ff", opacity: 0.8, weight: 1, fillColor: colorForTag(feature.properties.tag), fillOpacity: 0.2 };
+            },
+            onEachFeature: function (feature, layer) {
+              layer.bindTooltip('<strong>' + esc(feature.properties.tag.toUpperCase()) + '</strong> - ' + esc(feature.properties.label));
+              layer.on("click", function (event) {
+                if (event.originalEvent) L.DomEvent.stopPropagation(event.originalEvent);
+                useGeo({ lat: event.latlng.lat, lon: event.latlng.lng, name: feature.properties.label, countryCode: "ca", tag: feature.properties.tag }, false, feature.properties.tag);
+              });
+            }
+          }).addTo(map);
+          renderRegionBrowser(state.browseTag, false);
+          updateMapVisuals(false);
+        });
         map.on("click", function (event) {
           useGeo({
             lat: event.latlng.lat,
@@ -2989,10 +2980,8 @@
             countryCode: "ca"
           }, false, null);
         });
-        renderRegionBrowser(state.browseTag, false);
-        updateMapVisuals(Boolean(state.canGenerate));
-        window.setTimeout(function () { map.invalidateSize(); }, 0);
-        return new Promise(function (resolve, reject) {
+        window.setTimeout(function () { if (map === loadingMap) map.invalidateSize(); }, 0);
+        var tilesReady = new Promise(function (resolve, reject) {
           var settled = false;
           var timeout = window.setTimeout(function () {
             if (settled) return;
@@ -3003,6 +2992,7 @@
             if (settled) return;
             settled = true;
             window.clearTimeout(timeout);
+            if (map === loadingMap) els.mapLoading.hidden = true;
             resolve();
           });
           tileLayer.once("load", function () {
@@ -3012,8 +3002,10 @@
             reject(new Error("OpenStreetMap tiles could not load. Search and the region list still work."));
           });
         });
+        return Promise.all([tilesReady, boundariesReady]);
       }).then(function () {
         els.mapLoading.hidden = true;
+        els.boundaryStatus.hidden = true;
         els.mapLoadStatus.textContent = "";
         els.mapStage.setAttribute("aria-busy", "false");
         els.mapReadyStatus.textContent = "Interactive region map loaded.";
@@ -3024,9 +3016,13 @@
           try { map.remove(); } catch (cleanupError) { /* Leaflet may have failed during setup. */ }
           activeMaps = activeMaps.filter(function (entry) { return entry.map !== failedMap; });
           map = null;
+          marker = null;
+          browseLayer = null;
+          selectedLayer = null;
         }
         els.mapArea.hidden = true;
         els.mapLoading.hidden = false;
+        els.boundaryStatus.hidden = true;
         els.loadMap.hidden = false;
         mapIsLoading = false;
         els.mapLoadStatus.textContent = error.message || "The map could not load. Search and the region list still work.";
@@ -3169,7 +3165,6 @@
           "<td>" + (row.basis === "established" ? "Established" : "Proposed") + "</td>" +
           "</tr>";
       }).join("");
-      refreshIcons(el);
     }
     input.addEventListener("input", draw);
     province.addEventListener("change", draw);
@@ -3198,7 +3193,6 @@
       '</section>' +
       '</div>';
     renderRegionTable(el.querySelector("[data-role='dashboard-table']"), data);
-    refreshIcons(el);
   }
 
   function initRegions() {

--- a/docs/assets/regions/regions.js
+++ b/docs/assets/regions/regions.js
@@ -13,12 +13,24 @@
   var activeMaps = [];
   var LUCIDE_SRC = new URL("vendor/lucide.js", assetBase).href;
   var configuratorSupport = window.MeshCoreRegionConfiguratorSupport || {};
+  var radioProfiles = window.MeshCoreRadioProfiles;
   var REQUEST_TIMEOUT_MS = 12000;
   var frenchRuntime = /^fr(?:-|$)/i.test(
     document.documentElement ? document.documentElement.lang || "" : ""
   );
 
   var FRENCH_RUNTIME_TEXT = {
+    "Radio network": "Réseau radio",
+    "Advert ID size": "Taille de l’identifiant d’annonce",
+    "Keep current settings": "Conserver les réglages actuels",
+    "Choose a profile only after checking with your community. A region does not select a radio network.": "Confirmez le profil auprès de votre communauté. Une région ne détermine pas les réglages radio.",
+    "Radio changes take effect after reboot.": "Les changements radio prennent effet après le redémarrage.",
+    "Choose the region you mean:": "Choisissez la région recherchée :",
+    "This saved location is invalid or no longer available. Choose a region again.": "Cet emplacement est invalide ou n’est plus disponible. Choisissez une région à nouveau.",
+    "Setup summary": "Résumé de configuration",
+    "3 bytes": "3 octets",
+    "2 bytes": "2 octets",
+    "1 byte": "1 octet",
     "Unable to load MeshCore Canada region data": "Impossible de charger les données régionales de MeshCore Canada",
     "Unable to load the Canadian map layer": "Impossible de charger la couche cartographique canadienne",
     "Unable to load the Canadian location layer": "Impossible de charger la couche canadienne de localisation",
@@ -271,12 +283,15 @@
     "Open standard and change process": "Ouvrir la norme et le processus de modification",
     "Try again": "Réessayer",
     "Loading release evidence…": "Chargement des preuves de publication…",
-    "Select this leaf to see its full path.": "Sélectionnez cette région terminale pour voir son chemin complet.",
+    "Select this region to see its full path.": "Sélectionnez cette région pour voir son chemin complet.",
     "Province or territory": "Province ou territoire",
     "resolves to": "correspond à",
     "Aliases": "Alias",
     "None recorded": "Aucun",
-    "Planned paths": "Chemins prévus",
+    "Repeater paths": "Chemins du répéteur",
+    "Region details": "Détails de la région",
+    "Find a community": "Trouver une communauté",
+    "These are routing regions, not radio coverage boundaries.": "Ces régions servent au routage; elles ne représentent pas la portée radio.",
     "Configure this region": "Configurer cette région",
     "Copy link": "Copier le lien",
     "This location is outside Canada.": "Cet emplacement se trouve à l’extérieur du Canada.",
@@ -990,7 +1005,36 @@
     if (state.selectedExternalPaths && state.selectedExternalPaths.length) {
       params.set("external", state.selectedExternalPaths.join(","));
     }
+    if (state.firmware) params.set("firmware", state.firmware);
+    if (state.radioProfile) params.set("radio", state.radioProfile);
+    if (state.hashMode) params.set("hash", state.hashMode);
+    if (state.deviceRole) params.set("role", state.deviceRole);
+    if (state.wizardStep) params.set("step", state.wizardStep);
+    if (state.finishPath) params.set("instructions", state.finishPath);
     return regionPageHref("map") + (params.toString() ? "?" + params.toString() : "");
+  }
+
+  function keepLanguageSelection(state) {
+    document.querySelectorAll(".md-select__link[hreflang]").forEach(function (link) {
+      // Transfer only the tool's public selections, never arbitrary URL fields or secrets.
+      link.addEventListener("click", function () {
+        var target = new URL(link.href);
+        target.search = new URL(mapHrefForState(state)).search;
+        link.href = target.href;
+      });
+    });
+  }
+
+  function initialLocation(data, params) {
+    var tag = params.get("tag");
+    var seed = tag && seedForTag(data, tag);
+    if (tag && (!seed || statusFor(data, tag).state === "retired")) return null;
+    var point = params.has("lat") || params.has("lon")
+      ? configuratorSupport.parseCoordinates(params.get("lat"), params.get("lon"))
+      : seed;
+    if (!point) return null;
+    return { lat: point.lat, lon: point.lon, tag: tag || null, countryCode: "ca",
+      name: String(params.get("name") || (tag && labelFor(data, tag)) || "").slice(0, 160) };
   }
 
   function configHrefForState(state) {
@@ -1199,11 +1243,8 @@
     });
   }
 
-  function buildCommands(data, tags, firmware, includeBaseline, parentOverrides) {
-    var lines = [];
-    if (includeBaseline) {
-      lines = lines.concat(data.meta.baselineCommands || []);
-    }
+  function buildCommands(data, tags, firmware, settings, parentOverrides) {
+    var lines = radioProfiles ? radioProfiles.commands(settings.radioProfile, settings.hashMode) : [];
 
     if (firmware === "1.16") {
       var regionDefLine = "region def " + regionDefTokens(data, tags, parentOverrides).join(" ");
@@ -1342,12 +1383,14 @@
     if (!matches.length) return null;
     var best = matches[0];
     var tied = matches.filter(function (item) { return item.score === best.score; });
+    if (tied.length > 1 && best.score > 1) return null;
     if (tied.length > 1) {
       return {
         ambiguous: true,
         choices: tied.map(function (item) {
           var province = provinceTagFor(data, item.seed.tag);
-          return labelFor(data, item.seed.tag) + (province ? ", " + province.toUpperCase() : "");
+          return { tag: item.seed.tag, lat: item.seed.lat, lon: item.seed.lon, countryCode: "ca",
+            name: labelFor(data, item.seed.tag) + (province ? ", " + province.toUpperCase() : "") };
         })
       };
     }
@@ -1424,10 +1467,24 @@
     });
   }
 
+  function showLocationChoices(target, choices, choose) {
+    if (!choices) return;
+    choices.forEach(function (geo) {
+      var button = document.createElement("button");
+      button.type = "button";
+      button.className = "mcc-button mcc-button-secondary";
+      button.textContent = geo.name + " (" + geo.tag + ")";
+      button.addEventListener("click", function () { choose(geo); });
+      target.appendChild(button);
+    });
+  }
+
   function geocode(data, query, signal) {
     var localMatch = localGeocode(data, query);
     if (localMatch && localMatch.ambiguous) {
-      return Promise.reject(new Error("That name matches more than one region (" + localMatch.choices.join("; ") + "). Add a province or postal code."));
+      var error = new Error("Choose the region you mean:");
+      error.choices = localMatch.choices;
+      return Promise.reject(error);
     }
     if (localMatch && localMatch.exactLocalMatch) return Promise.resolve(localMatch);
     var postal = parseCanadianPostalCode(query);
@@ -1626,7 +1683,7 @@
       return;
     }
     var firmware = state.firmware || data.meta.defaultFirmware || "1.16";
-    var commands = buildCommands(data, rec.tags, firmware, state.includeBaseline, rec.parentOverrides);
+    var commands = buildCommands(data, rec.tags, firmware, state, rec.parentOverrides);
     var technicalCommands = commands.concat(["region", "region save", "region"]);
     var titleTag = state.resolution.primary.seed.tag;
     var statusNotes = rec.notes.map(function (note) {
@@ -1638,7 +1695,8 @@
     var firmwareLabel = firmware === "1.16" ? "v1.16+" : firmware === "1.15" ? "v1.15.x" : "v1.14.x";
     var guided = state.finishPath === "guided";
     var verificationCommands = ["region"];
-    if (state.includeBaseline) verificationCommands.push("get radio");
+    if (state.radioProfile !== "keep") verificationCommands.push("get radio");
+    if (state.hashMode !== "keep") verificationCommands.push("get path.hash.mode");
     var expectedPaths = rec.paths.map(function (path) { return labelledPath(data, path); });
     var expectedPathMarkup = '<div class="mcc-region-path-list">' + expectedPaths.map(function (path) {
       return "<span>" + esc(path) + "</span>";
@@ -1687,7 +1745,7 @@
         '<div class="mcc-guide-command-list"><button type="button" class="mcc-command-line" data-cmd="region"><span>region</span><em>' + icon("copy") + 'Copy</em></button></div>' +
         '<p>Save:</p>' +
         '<div class="mcc-guide-command-list"><button type="button" class="mcc-command-line" data-cmd="region save"><span>region save</span><em>' + icon("copy") + 'Copy</em></button></div>' +
-        '<p>' + (state.includeBaseline
+        '<p>' + (state.radioProfile !== "keep"
           ? 'Restart the device, reconnect, then run these final checks:'
           : 'Run this once more to confirm the saved region:') + '</p>' +
         '<div class="mcc-guide-command-list">' + verificationCommands.map(function (line) {
@@ -1736,10 +1794,12 @@
       (!guided ? '<button type="button" class="mcc-button mcc-copy-all">' + icon("copy") + 'Copy commands</button>' : '') +
       '</div>' +
       scopeNotice +
+      '<p class="mcc-note">' + esc(radioProfiles ? radioProfiles.label(state.radioProfile) : "Keep current settings") +
+      (state.radioProfile !== "keep" ? ' — <span>Radio changes take effect after reboot.</span>' : '') + '</p>' +
       technicalDetails +
       resultBody +
       '<section class="mcc-record-actions" aria-labelledby="mcc-record-heading">' +
-      '<div><h4 id="mcc-record-heading">Commissioning record</h4><p>Download or print a summary without exact coordinates, credentials, or device identifiers.</p></div>' +
+      '<div><h4 id="mcc-record-heading">Setup summary</h4><p>Download or print a summary without exact coordinates, credentials, or device identifiers.</p></div>' +
       '<div><button type="button" class="mcc-button mcc-button-secondary" data-action="download-commissioning">' + icon("download") + 'Download</button>' +
       '<button type="button" class="mcc-button mcc-button-secondary" data-action="print-commissioning">' + icon("printer") + 'Print</button></div>' +
       '</section>' +
@@ -1795,7 +1855,7 @@
     if (!rec) return null;
     if (rec.budget.tagCount > 32 || rec.budget.responseBytes > 172) return null;
     var firmware = state.firmware || data.meta.defaultFirmware || "1.16";
-    return buildCommands(data, rec.tags, firmware, state.includeBaseline, rec.parentOverrides)
+    return buildCommands(data, rec.tags, firmware, state, rec.parentOverrides)
       .concat(["region", "region save", "region"]);
   }
 
@@ -1811,6 +1871,8 @@
       homeRegion: labelledPath(data, ancestryFor(data, homeTag)),
       firmware: state.firmware === "1.16" ? "v1.16+" : "v" + state.firmware + ".x",
       budget: rec.budget.tagCount + " / 32 tags, " + rec.budget.responseBytes + " / 172 bytes",
+      radio: radioProfiles ? radioProfiles.label(state.radioProfile) : "Keep current settings",
+      hashMode: state.hashMode === "keep" ? "Keep current settings" : (state.hashMode === "0" ? "1 byte" : String(Number(state.hashMode) + 1) + " bytes"),
       paths: rec.paths.map(function (path) { return labelledPath(data, path); }),
       commands: commands
     });
@@ -2035,12 +2097,13 @@
       '<label class="mcc-choice"><input type="radio" name="mcc-type" value="high-site"><span><strong>Add nearby or cross-border paths</strong><small>For bridge, wide-coverage, mountain, or water-path repeaters</small></span></label>' +
       '</div>' +
       '<div data-role="metro"></div>' +
+      '<label class="mcc-label" for="mcc-radio-profile">Radio network</label>' +
+      '<select class="mcc-select" id="mcc-radio-profile"><option value="keep">Keep current settings</option></select>' +
+      '<p class="mcc-hint">Choose a profile only after checking with your community. A region does not select a radio network.</p>' +
+      '<label class="mcc-label" for="mcc-hash-mode">Advert ID size</label>' +
+      '<select class="mcc-select" id="mcc-hash-mode"><option value="keep">Keep current settings</option><option value="2">3 bytes</option><option value="1">2 bytes</option><option value="0">1 byte</option></select>' +
       '<details class="mcc-advanced-options" data-role="technical-settings">' +
-      '<summary>Radio and firmware options</summary>' +
-      '<div class="mcc-choice-list" data-role="device-path" role="radiogroup" aria-label="Recommended radio settings">' +
-      '<label class="mcc-choice"><input type="radio" name="mcc-device-path" value="new" checked><span><strong>Include recommended radio defaults</strong><small>For a new setup</small></span></label>' +
-      '<label class="mcc-choice"><input type="radio" name="mcc-device-path" value="existing"><span><strong>Keep current radio settings</strong><small>For an existing coordinated network</small></span></label>' +
-      '</div>' +
+      '<summary>Firmware version</summary>' +
       '<p class="mcc-label">Firmware version</p>' +
       '<div class="mcc-choice-list" data-role="firmware" role="radiogroup" aria-label="Firmware version">' +
       '<label class="mcc-choice"><input type="radio" name="mcc-firmware" value="1.16" checked><span><strong>v1.16+</strong></span></label>' +
@@ -2077,7 +2140,8 @@
       deviceRole: "repeater",
       type: "residential",
       firmware: data.meta.defaultFirmware || "1.16",
-      includeBaseline: true,
+      radioProfile: "keep",
+      hashMode: "keep",
       selectedMetros: [],
       selectedExternalPaths: [],
       canGenerate: false,
@@ -2141,6 +2205,8 @@
         '<div><dt>Node</dt><dd>' + esc(deviceLabels[state.deviceRole] || deviceLabels.repeater) + '</dd></div>' +
         '<div><dt>Place</dt><dd>' + esc(state.name || labelFor(data, state.resolution.primary.seed.tag)) + '</dd></div>' +
         '<div><dt>Home region</dt><dd>' + esc(labelledPath(data, ancestryFor(data, state.resolution.primary.seed.tag))) + '</dd></div>' +
+        '<div><dt>Radio network</dt><dd>' + esc(radioProfiles ? radioProfiles.label(state.radioProfile) : "Keep current settings") + '</dd></div>' +
+        '<div><dt>Advert ID size</dt><dd>' + (state.hashMode === "keep" ? 'Keep current settings' : state.hashMode === "0" ? '1 byte' : esc(Number(state.hashMode) + 1) + ' bytes') + '</dd></div>' +
         '<div><dt>Budget</dt><dd>' + esc(rec.budget.tagCount) + ' / 32 tags · ' + esc(rec.budget.responseBytes) + ' / 172 bytes</dd></div>' +
         '</dl>' +
         '<h3>Forwarding paths</h3><ul class="mcc-review-paths">' + paths + '</ul>' +
@@ -2179,6 +2245,7 @@
           heading.focus({ preventScroll: true });
         }
       }
+      updateMapLinks();
       refreshIcons(el);
     }
 
@@ -2190,6 +2257,7 @@
         button.setAttribute("aria-pressed", active ? "true" : "false");
       });
       renderResult(data, els.result, state);
+      updateMapLinks();
     }
 
     function advanceStep() {
@@ -2333,6 +2401,7 @@
         if (err && err.name === "AbortError") return;
         state.canGenerate = false;
         setStatus(els.status, esc(err.message || "Location lookup failed"), "error");
+        showLocationChoices(els.status, err.choices, useGeo);
         refreshTool(data, els, state, updateMapLinks);
       }).finally(function () {
         if (activeGeocodeController !== thisController) return;
@@ -2419,14 +2488,13 @@
       input.addEventListener("change", function () {
         state.deviceRole = input.value;
         if (state.deviceRole === "advanced" && els.technicalSettings) els.technicalSettings.open = true;
+        updateMapLinks();
       });
     });
-    el.querySelectorAll("input[name='mcc-device-path']").forEach(function (input) {
-      input.addEventListener("change", function () {
-        state.includeBaseline = input.value === "new";
-        renderResult(data, els.result, state);
-      });
-    });
+    var profileSelect = el.querySelector("#mcc-radio-profile");
+    var hashSelect = el.querySelector("#mcc-hash-mode");
+    profileSelect.addEventListener("change", function () { state.radioProfile = profileSelect.value; updateMapLinks(); });
+    hashSelect.addEventListener("change", function () { state.hashMode = hashSelect.value; updateMapLinks(); });
     el.querySelectorAll("input[name='mcc-type']").forEach(function (input) {
       input.addEventListener("change", function () {
         state.type = input.value;
@@ -2440,13 +2508,52 @@
       input.addEventListener("change", function () {
         state.firmware = input.value;
         renderResult(data, els.result, state);
+        updateMapLinks();
       });
     });
     renderConfigRegionBrowser(state.browseTag);
     updateMapLinks();
     var initialParams = new URLSearchParams(window.location.search);
+    keepLanguageSelection(state);
+    var profileReady = radioProfiles ? radioProfiles.populate(profileSelect) : Promise.resolve();
+    profileReady.then(function () {
+      if (Array.from(profileSelect.options).some(function (option) { return option.value === initialParams.get("radio"); })) {
+        state.radioProfile = profileSelect.value = initialParams.get("radio");
+        updateMapLinks();
+        if (state.wizardStep === 4) showStep(4);
+      }
+    });
+    [["firmware", "mcc-firmware", ["1.14", "1.15", "1.16"]],
+      ["deviceRole", "mcc-device-role", ["repeater", "room", "advanced"]]].forEach(function (entry) {
+      var value = initialParams.get(entry[0] === "deviceRole" ? "role" : entry[0]);
+      if (entry[2].indexOf(value) !== -1) {
+        state[entry[0]] = value;
+        el.querySelector("input[name='" + entry[1] + "'][value='" + value + "']").checked = true;
+      }
+    });
+    if (["0", "1", "2"].indexOf(initialParams.get("hash")) !== -1) state.hashMode = hashSelect.value = initialParams.get("hash");
+    if (initialParams.get("instructions") === "technical") selectFinishPath("technical");
+    var location = initialLocation(data, initialParams);
     var initialQuery = (initialParams.get("place") || "").trim();
-    if (initialQuery) {
+    if (location) {
+      els.input.value = location.name;
+      useGeo(location).then(function () {
+        if (!state.canGenerate) return;
+        if (initialParams.get("type") === "large") {
+          state.type = "high-site";
+          el.querySelector("input[name='mcc-type'][value='high-site']").checked = true;
+          state.selectedMetros = String(initialParams.get("regions") || "").split(",").filter(function (tag) { return Boolean(seedForTag(data, tag)); });
+          state.selectedExternalPaths = selectedExternalRegionPaths(data, String(initialParams.get("external") || "").split(",")).map(function (record) { return record.id; });
+        }
+        state.maxStep = 4;
+        refreshTool(data, els, state, updateMapLinks);
+        showStep(/^[1-4]$/.test(initialParams.get("step")) ? Number(initialParams.get("step")) : 3);
+      });
+    } else if (initialParams.has("tag") || initialParams.has("lat") || initialParams.has("lon")) {
+      state.maxStep = 2;
+      showStep(2);
+      setStatus(els.status, "This saved location is invalid or no longer available. Choose a region again.", "warning");
+    } else if (initialQuery) {
       state.maxStep = 2;
       els.input.value = initialQuery;
       showStep(2);
@@ -2502,11 +2609,11 @@
       '</div><button class="mcc-button mcc-button-secondary" type="button" data-action="map-use-coordinates">Use coordinates</button></details>' +
       '<div data-role="map-status"></div>' +
       '</section>' +
-      '<section class="mcc-card mcc-card-compact">' +
-      '<h3>Browse by province or territory</h3>' +
+      '<details class="mcc-card mcc-card-compact" data-role="map-region-browser">' +
+      '<summary>Browse by province or territory</summary>' +
       '<div class="mcc-region-breadcrumbs" data-role="region-breadcrumbs"></div>' +
       '<div class="mcc-region-children" data-role="region-children"></div>' +
-      '</section>' +
+      '</details>' +
       '<section class="mcc-card mcc-dynamic-card" data-role="map-result-section" hidden>' +
       '<h3>Selected region</h3><div data-role="map-text-result"></div>' +
       '</section>' +
@@ -2558,7 +2665,8 @@
       jurisdictionTag: null,
       type: requestedLargeCoverage ? "high-site" : "residential",
       firmware: data.meta.defaultFirmware || "1.16",
-      includeBaseline: true,
+      radioProfile: "keep",
+      hashMode: ["0", "1", "2"].indexOf(mapParams.get("hash")) !== -1 ? mapParams.get("hash") : "keep",
       selectedMetros: requestedLargeCoverage ? requestedCanadianRegions : [],
       selectedExternalPaths: requestedLargeCoverage ? requestedExternalPaths : [],
       canGenerate: false,
@@ -2681,7 +2789,7 @@
           '<span><strong>' + esc(labelFor(data, child)) + '</strong><small>' +
           (nested ? leafCount + ' subregions' : child.toUpperCase() + ' · region') +
           '</small></span><span aria-hidden="true">' + (nested ? '›' : '✓') + '</span></button>';
-      }).join("") : '<p class="mcc-help">Select this leaf to see its full path.</p>';
+      }).join("") : '<p class="mcc-help">Select this region to see its full path.</p>';
       if (!map || !browseLayer) return;
       browseLayer.clearLayers();
       if (tag !== (data.meta.rootTag || "can") && data.partitionByTag) {
@@ -2728,15 +2836,22 @@
         return normalizeLocationSearch(alias) !== normalizeLocationSearch(tag) &&
           normalizeLocationSearch(alias) !== normalizeLocationSearch(labelFor(data, tag));
       });
+      aliases = aliases.filter(function (alias, index) {
+        return aliases.findIndex(function (item) { return normalizeLocationSearch(item) === normalizeLocationSearch(alias); }) === index;
+      });
+      var communityUrl = new URL("../provinces/", regionPageHref("config"));
+      communityUrl.searchParams.set("community", labelFor(data, provinceTagFor(data, tag)));
       els.resultSection.hidden = false;
       els.textResult.innerHTML =
         '<p class="mcc-deterministic-result"><strong>' + esc(state.name) + '</strong> resolves to <strong>' +
         esc(labelFor(data, tag)) + '</strong> (<code>' + esc(tag) + '</code>).</p>' +
         '<p class="mcc-region-path">' + esc(labelledPath(data, ancestryFor(data, tag))) + '</p>' +
-        '<dl class="mcc-review-list"><div><dt>Province or territory</dt><dd>' + esc(labelFor(data, provinceTagFor(data, tag))) + '</dd></div>' +
+        '<p>These are routing regions, not radio coverage boundaries.</p>' +
+        '<p><a href="' + esc(communityUrl.href) + '">Find a community</a></p>' +
+        '<details><summary>Region details</summary><dl class="mcc-review-list"><div><dt>Province or territory</dt><dd>' + esc(labelFor(data, provinceTagFor(data, tag))) + '</dd></div>' +
         '<div><dt>Status</dt><dd>' + esc(statusLabel(statusFor(data, tag).state || "draft")) + '</dd></div>' +
         '<div><dt>Aliases</dt><dd>' + esc(aliases.length ? aliases.join(", ") : "None recorded") + '</dd></div>' +
-        '<div><dt>Planned paths</dt><dd>' + esc(rec ? rec.paths.length : 1) + '</dd></div></dl>' +
+        '<div><dt>Repeater paths</dt><dd>' + esc(rec ? rec.paths.length : 1) + '</dd></div></dl></details>' +
         '<div class="mcc-detail-actions"><a class="mcc-button" href="' + esc(configHrefForState(state)) + '">Configure this region</a>' +
         '<button type="button" class="mcc-button mcc-button-secondary" data-action="copy-region-link">' + icon("link") + 'Copy link</button></div>';
       var copyLink = els.textResult.querySelector("[data-action='copy-region-link']");
@@ -2812,6 +2927,7 @@
         .catch(function (error) {
           if (error && error.name === "AbortError") return;
           setStatus(els.status, esc(error.message || "Location lookup failed"), "error");
+          showLocationChoices(els.status, error.choices, function (geo) { return useGeo(geo, true, geo.tag); });
         }).finally(function () {
           if (activeGeocodeController !== thisController) return;
           els.locate.disabled = false;
@@ -2941,18 +3057,24 @@
     renderRegionTable(els.table, data, function (tag) { chooseRegionNode(tag); });
     window.setTimeout(loadInteractiveMap, 0);
 
-    var initialLat = Number(mapParams.get("lat"));
-    var initialLon = Number(mapParams.get("lon"));
-    var hasInitialLocation = mapParams.has("lat") && mapParams.has("lon") &&
-      Number.isFinite(initialLat) && Number.isFinite(initialLon) &&
-      initialLat >= -90 && initialLat <= 90 && initialLon >= -180 && initialLon <= 180;
-    if (hasInitialLocation) {
-      var requestedTag = slug(mapParams.get("tag"));
-      if (!data.hierarchy[requestedTag] || !seedForTag(data, requestedTag)) requestedTag = null;
-      var initialName = String(mapParams.get("name") || "").slice(0, 160) ||
-        initialLat.toFixed(4) + ", " + initialLon.toFixed(4);
-      els.input.value = initialName;
-      useGeo({ lat: initialLat, lon: initialLon, name: initialName, countryCode: "ca", tag: requestedTag }, false, requestedTag);
+    keepLanguageSelection(state);
+    // Load the same validated profile list used by the configurator before carrying a choice back.
+    if (radioProfiles) radioProfiles.populate(document.createElement("select")).then(function () {
+      try {
+        radioProfiles.commands(mapParams.get("radio"), "keep");
+        state.radioProfile = mapParams.get("radio") || "keep";
+      } catch (_) { state.radioProfile = "keep"; }
+      renderTextResult();
+    });
+    if (["1.14", "1.15", "1.16"].indexOf(mapParams.get("firmware")) !== -1) state.firmware = mapParams.get("firmware");
+    if (["repeater", "room", "advanced"].indexOf(mapParams.get("role")) !== -1) state.deviceRole = mapParams.get("role");
+    if (["guided", "technical"].indexOf(mapParams.get("instructions")) !== -1) state.finishPath = mapParams.get("instructions");
+    var initialGeo = initialLocation(data, mapParams);
+    if (initialGeo) {
+      els.input.value = initialGeo.name;
+      useGeo(initialGeo, false, initialGeo.tag);
+    } else if (mapParams.has("tag") || mapParams.has("lat") || mapParams.has("lon")) {
+      setStatus(els.status, "This saved location is invalid or no longer available. Choose a region again.", "warning");
     }
     setMapMode(mapParams.get("view") === "audit" ? "audit" : "explore");
   }

--- a/docs/assets/regions/regions.js
+++ b/docs/assets/regions/regions.js
@@ -394,9 +394,6 @@
     [/^(.+) resolves to (.+)$/, function (match, place, region) {
       return place + " correspond à " + region;
     }],
-    [/^Text result: (.+)\.$/, function (match, path) {
-      return "Résultat textuel : " + path + ".";
-    }],
     [/^(\d+) leaf regions$/, function (match, count) {
       return count + " régions terminales";
     }],
@@ -2883,8 +2880,7 @@
       if (!state.canGenerate) {
         setStatus(els.status, "No Canadian region contains that point. Browse the list instead.", "warning");
       } else {
-        var path = labelledPath(data, ancestryFor(data, state.detailTag));
-        setStatus(els.status, "Text result: " + esc(path) + ".", "info");
+        setStatus(els.status, "Region found.", "info");
         renderRegionBrowser(state.detailTag, false);
       }
       renderTextResult();
@@ -2962,6 +2958,7 @@
       Promise.all([loadDisplayPartition(), loadLeaflet()]).then(function (loaded) {
         applyGeneratedPartition(data, loaded[0], null);
         var L = loaded[1];
+        L.Icon.Default.imagePath = new URL("vendor/leaflet/images/", assetBase).href;
         els.mapArea.hidden = false;
         map = L.map(els.canvas, { minZoom: 3, maxZoom: 13 });
         activeMaps.push({ container: el, map: map });
@@ -3054,8 +3051,31 @@
     els.coordinates.addEventListener("click", useCoordinates);
     els.loadMap.addEventListener("click", loadInteractiveMap);
     renderRegionBrowser(state.browseTag, false);
-    renderRegionTable(els.table, data, function (tag) { chooseRegionNode(tag); });
-    window.setTimeout(loadInteractiveMap, 0);
+    var regionList = el.querySelector("#mcc-region-list");
+    function ensureRegionTable() {
+      if (!els.table.firstChild) renderRegionTable(els.table, data);
+    }
+    regionList.addEventListener("toggle", function () {
+      if (regionList.open) ensureRegionTable();
+    });
+    el.querySelector(".mcc-skip-map").addEventListener("click", function () {
+      regionList.open = true;
+      ensureRegionTable();
+    });
+    function observeInteractiveMap() {
+      // Text lookup is useful on its own; download the display layer only when it is visible.
+      if ("IntersectionObserver" in window) {
+        var mapObserver = new IntersectionObserver(function (entries) {
+          if (entries.some(function (entry) { return entry.isIntersecting; })) {
+            mapObserver.disconnect();
+            loadInteractiveMap();
+          }
+        });
+        mapObserver.observe(els.mapStage);
+      } else {
+        window.setTimeout(loadInteractiveMap, 0);
+      }
+    }
 
     keepLanguageSelection(state);
     // Load the same validated profile list used by the configurator before carrying a choice back.
@@ -3072,9 +3092,13 @@
     var initialGeo = initialLocation(data, mapParams);
     if (initialGeo) {
       els.input.value = initialGeo.name;
-      useGeo(initialGeo, false, initialGeo.tag);
-    } else if (mapParams.has("tag") || mapParams.has("lat") || mapParams.has("lon")) {
-      setStatus(els.status, "This saved location is invalid or no longer available. Choose a region again.", "warning");
+      // Let the result card settle before measuring whether the map is on screen.
+      useGeo(initialGeo, false, initialGeo.tag).then(observeInteractiveMap);
+    } else {
+      if (mapParams.has("tag") || mapParams.has("lat") || mapParams.has("lon")) {
+        setStatus(els.status, "This saved location is invalid or no longer available. Choose a region again.", "warning");
+      }
+      observeInteractiveMap();
     }
     setMapMode(mapParams.get("view") === "audit" ? "audit" : "explore");
   }

--- a/docs/assets/regions/vendor/README.txt
+++ b/docs/assets/regions/vendor/README.txt
@@ -14,3 +14,7 @@ The CSS differs from upstream only by git CRLF→LF normalization.
 UMD distribution from npm.
 
 - `lucide.js`: `8c6fb02591ab1afdf712fa06bc9ac41124f48a729cd07aa1b6eec705f7f92f34`
+
+The region tools embed only their 17 SVG icons in regions.js. They no longer
+download the full Lucide library. The original bundle is retained as the
+reference for the icon consistency test; see lucide-LICENSE for its notices.

--- a/docs/assets/regions/vendor/lucide-LICENSE
+++ b/docs/assets/regions/vendor/lucide-LICENSE
@@ -1,0 +1,39 @@
+ISC License
+
+Copyright (c) for portions of Lucide are held by Cole Bemis 2013-2023 as part of Feather (MIT). All other copyright (c) for Lucide are held by Lucide Contributors 2025.
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+---
+
+The MIT License (MIT) (for portions derived from Feather)
+
+Copyright (c) 2013-2023 Cole Bemis
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/docs/config/editor/issue.js
+++ b/docs/config/editor/issue.js
@@ -159,7 +159,8 @@ export function validateSubmissionConfig(value, endpoint = DEFAULT_SUBMISSION_EN
     version: SUBMISSION_CONTRACT_VERSION,
     endpoint: cleanEndpoint(endpoint),
     turnstileSiteKey: siteKey,
-    turnstileAction: action
+    turnstileAction: action,
+    ...(value.communityIdeaOptionalDetails === true ? { communityIdeaOptionalDetails: true } : {})
   });
 }
 

--- a/docs/config/index.fr.md
+++ b/docs/config/index.fr.md
@@ -14,10 +14,11 @@ tested_with:
 difficulty: intermediate
 estimated_time: 5-10 minutes
 page_styles:
-  - assets/regions/regions.css?v=20260820-1
+  - assets/regions/regions.css?v=20260904-1
 page_scripts:
-  - assets/regions/modules/configurator-support.js?v=20260722-2
-  - assets/regions/regions.js?v=20260820-1
+  - assets/javascripts/radio-profiles.js?v=20260904-1
+  - assets/regions/modules/configurator-support.js?v=20260904-1
+  - assets/regions/regions.js?v=20260904-1
 hide:
   - navigation
   - toc

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -14,10 +14,11 @@ tested_with:
 difficulty: intermediate
 estimated_time: 5-10 minutes
 page_styles:
-  - assets/regions/regions.css?v=20260820-1
+  - assets/regions/regions.css?v=20260904-1
 page_scripts:
-  - assets/regions/modules/configurator-support.js?v=20260722-2
-  - assets/regions/regions.js?v=20260820-1
+  - assets/javascripts/radio-profiles.js?v=20260904-1
+  - assets/regions/modules/configurator-support.js?v=20260904-1
+  - assets/regions/regions.js?v=20260904-1
 hide:
   - navigation
   - toc

--- a/docs/config/map.fr.md
+++ b/docs/config/map.fr.md
@@ -15,10 +15,11 @@ tested_with:
   region_catalog: national-partition-2026-07-19
 difficulty: beginner
 page_styles:
-  - assets/regions/regions.css?v=20260820-1
+  - assets/regions/regions.css?v=20260904-1
 page_scripts:
-  - assets/regions/modules/configurator-support.js?v=20260722-2
-  - assets/regions/regions.js?v=20260820-1
+  - assets/javascripts/radio-profiles.js?v=20260904-1
+  - assets/regions/modules/configurator-support.js?v=20260904-1
+  - assets/regions/regions.js?v=20260904-1
 hide:
   - toc
 ---

--- a/docs/config/map.md
+++ b/docs/config/map.md
@@ -15,10 +15,11 @@ tested_with:
   region_catalog: national-partition-2026-07-19
 difficulty: beginner
 page_styles:
-  - assets/regions/regions.css?v=20260820-1
+  - assets/regions/regions.css?v=20260904-1
 page_scripts:
-  - assets/regions/modules/configurator-support.js?v=20260722-2
-  - assets/regions/regions.js?v=20260820-1
+  - assets/javascripts/radio-profiles.js?v=20260904-1
+  - assets/regions/modules/configurator-support.js?v=20260904-1
+  - assets/regions/regions.js?v=20260904-1
 hide:
   - toc
 ---

--- a/docs/config/standard.fr.md
+++ b/docs/config/standard.fr.md
@@ -6,7 +6,7 @@ audience:
   - region-maintainer
 task: understand-region-standard
 scope: canada-baseline
-status: verified
+status: draft
 owner: region-maintainers
 last_reviewed: 2026-07-19
 review_by: 2026-10-19
@@ -16,6 +16,18 @@ difficulty: advanced
 ---
 
 # Définition des régions et autorité de MeshCore Canada
+
+## Pour configurer votre appareil
+
+1. [Trouvez votre région](map.md).
+2. Confirmez les réglages radio auprès de votre [communauté](../provinces/index.md).
+3. Sur un répéteur, [préparez les chemins régionaux](index.md), vérifiez-les, puis enregistrez-les.
+
+Une région organise le routage; elle ne garantit pas la portée radio. Ottawa–Gatineau et Lloydminster utilisent plusieurs chemins pour leur zone partagée.
+
+Le reste de cette page décrit les règles proposées et les contrôles destinés aux responsables du registre. Les modifications de limites nécessitent un examen communautaire.
+
+## Référence du registre
 
 Cette norme définit les régions MeshCore du Canada. Elle explique comment les
 emplacements et les limites sont attribués, qui approuve les changements et
@@ -29,7 +41,7 @@ comment les conflits entre sources sont résolus.
 | Entrée sémantique actuelle | Canada MeshCore Region Strategy v1.1.1 |
 | Entrée actuelle pour les limites communautaires | Instantané MeshMapper Canada, 2026-07-12 |
 | Preuve opérationnelle actuelle | Instantané canadien de densité radio protégeant la vie privée, 2026-07-15 UTC; instantané agrégé des routes Canada–États-Unis, 2026-07-18 |
-| Adoption | Devient normative après approbation et fusion par MeshCore Canada |
+| Adoption | Examen communautaire; publier cette page ne signifie pas que tous les réseaux l’ont adoptée |
 
 Statistique Canada emploie en français les termes **aire de diffusion (AD)**,
 **subdivision de recensement (SDR)**, **division de recensement (DR)** et

--- a/docs/config/standard.md
+++ b/docs/config/standard.md
@@ -6,7 +6,7 @@ audience:
   - region-maintainer
 task: understand-region-standard
 scope: canada-baseline
-status: verified
+status: draft
 owner: region-maintainers
 last_reviewed: 2026-07-19
 review_by: 2026-10-19
@@ -16,6 +16,18 @@ difficulty: advanced
 ---
 
 # MeshCore Canada region definition and authority
+
+## Setting up a device?
+
+1. [Find your region](map.md).
+2. Confirm the radio settings with your [community](../provinces/index.md).
+3. For a repeater, [prepare its region paths](index.md), check them, then save.
+
+A region organizes routing; it does not guarantee radio coverage. Ottawa–Gatineau and Lloydminster use several paths for their shared area.
+
+The rest of this page documents proposed registry rules and maintainer checks. Boundary changes still require community review.
+
+## Registry reference
 
 This standard defines Canada's MeshCore regions. It explains how locations and
 boundaries are assigned, who approves changes, and how source conflicts are
@@ -29,7 +41,7 @@ resolved.
 | Current semantic input | Canada MeshCore Region Strategy v1.1.1 |
 | Current community boundary input | MeshMapper Canada snapshot, 2026-07-12 |
 | Current operational evidence | Privacy-safe Canadian radio-density snapshot, 2026-07-15 UTC; aggregate Canada–U.S. route snapshot, 2026-07-18 |
-| Adoption | Becomes normative when approved and merged by MeshCore Canada |
+| Adoption | Community review; publishing this page does not establish network-wide adoption |
 
 !!! important "What is authoritative today?"
     This page and the generated national partition are proposed for review. The candidate assigns every digital DA exactly once and the public map renders only dissolved leaf regions. No raw source polygon or approximate circle is a boundary. The partition becomes operationally authoritative only after community review and every release check in this standard passes.

--- a/docs/hardware/recommended-antenna.fr.md
+++ b/docs/hardware/recommended-antenna.fr.md
@@ -56,9 +56,9 @@ Ce sont des antennes SMA, plus compactes, qui ont pourtant constamment offert un
 
 | Produit | Connecteur | Coût (CAD) | Lien |
 |---|---|---|---|
-| Gizont 167CM 915MHz SMA M | SMA | 12 $ | [Space Hedgehog (boutique locale)](https://space-hedgehog.com/products/gizont-915mhz-antenna?variant=51602989711416) |
-| Gizont 167CM 915MHz SMA M | SMA | 10,53 $ | [AliExpress](https://www.aliexpress.com/item/1005004607615001.html) |
-| Gizont 167CM 915MHz RP-SMA M | RP-SMA | 10,53 $ | [AliExpress](https://www.aliexpress.com/item/1005004607615001.html) |
+| Gizont 915 MHz SMA M | SMA | 12 $ | [Space Hedgehog (boutique locale)](https://space-hedgehog.com/products/gizont-915mhz-antenna?variant=51602989711416) |
+| Gizont 915 MHz SMA M | SMA | 10,53 $ | [AliExpress](https://www.aliexpress.com/item/1005004607615001.html) |
+| Gizont 915 MHz RP-SMA M | RP-SMA | 10,53 $ | [AliExpress](https://www.aliexpress.com/item/1005004607615001.html) |
 | LINX ANT-916-CW-HW-SMA | SMA | 14,65 $ | [DigiKey](https://www.digikey.ca/en/products/detail/te-connectivity-linx/ANT-916-CW-HW-SMA/2694126?s=N4IgTCBcDaIDIEkByANABAQSQFQLQE4BGANlwGEB1XACSoGUBZDEAXQF8g) |
 | Taoglas TI.09.A.0111 | SMA | 17,47 $ | [DigiKey](https://www.digikey.ca/en/products/detail/taoglas-limited/TI-09-A-0111/2332695?s=N4IgTCBcDaICoEMD2BzANggzgAjgSQDoAGATgIEFiBGGkAXQF8g) |
 | Seeed Studio LoRa Antenna Kit | SMA | 6,79 $ | [Seeed Studio](https://www.seeedstudio.com/LoRa-Antenna-Kit-for-reTerminal-DM-p-5714.html) |

--- a/docs/hardware/recommended-antenna.md
+++ b/docs/hardware/recommended-antenna.md
@@ -56,9 +56,9 @@ These are SMA antennas and are more compact, yet they've consistently shown exce
 
 | Product | Connector | Cost (CAD) | Link |
 |---|---|---|---|
-| Gizont 167CM 915MHz SMA M | SMA | $12 | [Space Hedgehog (local store)](https://space-hedgehog.com/products/gizont-915mhz-antenna?variant=51602989711416) |
-| Gizont 167CM 915MHz SMA M | SMA | $10.53 | [AliExpress](https://www.aliexpress.com/item/1005004607615001.html) |
-| Gizont 167CM 915MHz RP-SMA M | RP-SMA | $10.53 | [AliExpress](https://www.aliexpress.com/item/1005004607615001.html) |
+| Gizont 915 MHz SMA M | SMA | $12 | [Space Hedgehog (local store)](https://space-hedgehog.com/products/gizont-915mhz-antenna?variant=51602989711416) |
+| Gizont 915 MHz SMA M | SMA | $10.53 | [AliExpress](https://www.aliexpress.com/item/1005004607615001.html) |
+| Gizont 915 MHz RP-SMA M | RP-SMA | $10.53 | [AliExpress](https://www.aliexpress.com/item/1005004607615001.html) |
 | LINX ANT-916-CW-HW-SMA | SMA | $14.65 | [DigiKey](https://www.digikey.ca/en/products/detail/te-connectivity-linx/ANT-916-CW-HW-SMA/2694126?s=N4IgTCBcDaIDIEkByANABAQSQFQLQE4BGANlwGEB1XACSoGUBZDEAXQF8g) |
 | Taoglas TI.09.A.0111 | SMA | $17.47 | [DigiKey](https://www.digikey.ca/en/products/detail/taoglas-limited/TI-09-A-0111/2332695?s=N4IgTCBcDaICoEMD2BzANggzgAjgSQDoAGATgIEFiBGGkAXQF8g) |
 | Seeed Studio LoRa Antenna Kit | SMA | $6.79 | [Seeed Studio](https://www.seeedstudio.com/LoRa-Antenna-Kit-for-reTerminal-DM-p-5714.html) |

--- a/docs/hardware/recommended-companions.fr.md
+++ b/docs/hardware/recommended-companions.fr.md
@@ -81,11 +81,11 @@ Il s’agit d’un rôle de **compagnon** et il exige un téléphone intelligent
 | **Carte LoRa** | Heltec T114 (ensemble avec écran) | 45,99 $ | [AliExpress](https://www.aliexpress.com/item/1005007916299029.html) |
 | **Câble IPEX à SMA à angle droit** | SMA-KW 2PCS 8cm | 4,67 $ | [AliExpress](https://www.aliexpress.com/item/1005009270132403.html) |
 | **Pile** | MakerFocus LiPo 3,7 V 3000 mAh (paquet de 4), connecteur Micro JST 1.5 avec circuit de protection | 34,34 $ | [MakerFocus](https://www.makerfocus.com/products/makerfocus-3-7v-3000mah-lithium-rechargeable-battery-1s-3c-lipo-battery-pack-of-4?variant=44823607541998) |
-| **Antenne** | Gizont 167CM 915MHz SMA M | 10,68 $ | [AliExpress](https://www.aliexpress.com/item/1005004607615001.html) (assurez-vous de choisir la bonne antenne à l’ouverture du lien) |
+| **Antenne** | Gizont 915 MHz SMA M | 10,68 $ | [AliExpress](https://www.aliexpress.com/item/1005004607615001.html) (assurez-vous de choisir la bonne antenne à l’ouverture du lien) |
 
 </div>
 
-*Coût total approximatif :* **95,68 $ CAD**
+*Total de cet exemple d’achat :* **95,68 $ CAD**, dont un lot de quatre piles et deux câbles. Ce n’est pas le coût par appareil.
 
 *Les prix datent du 2 septembre 2026. Consultez les pages liées pour vérifier les prix, l’expédition, les droits de douane et la disponibilité.*
 

--- a/docs/hardware/recommended-companions.md
+++ b/docs/hardware/recommended-companions.md
@@ -81,11 +81,11 @@ This is a **companion node** role and requires a smartphone. The MeshCore app co
 | **LoRa board** | Heltec T114 (bundle with screen) | $45.99 | [AliExpress](https://www.aliexpress.com/item/1005007916299029.html) |
 | **Right-angle IPEX to SMA pigtail cable** | SMA-KW 2PCS 8cm | $4.67 | [AliExpress](https://www.aliexpress.com/item/1005009270132403.html) |
 | **Battery** | MakerFocus 3.7V 3000mAh LiPo (pack of 4), Micro JST 1.5 connection with protection board | $34.34 | [MakerFocus](https://www.makerfocus.com/products/makerfocus-3-7v-3000mah-lithium-rechargeable-battery-1s-3c-lipo-battery-pack-of-4?variant=44823607541998) |
-| **Antenna** | Gizont 167CM 915MHz SMA M | $10.68 | [AliExpress](https://www.aliexpress.com/item/1005004607615001.html) (make sure you select the right antenna when opening the link) |
+| **Antenna** | Gizont 915 MHz SMA M | $10.68 | [AliExpress](https://www.aliexpress.com/item/1005004607615001.html) (make sure you select the right antenna when opening the link) |
 
 </div>
 
-*Approximate total cost:* **$95.68 CAD**
+*Example shopping total:* **$95.68 CAD**, including a four-battery pack and two pigtails. This is not the per-device cost.
 
 *Prices are dated September 2, 2026. Check the linked pages for current prices, shipping, duties, and availability.*
 

--- a/docs/hardware/repeater-mounting-options.fr.md
+++ b/docs/hardware/repeater-mounting-options.fr.md
@@ -138,11 +138,9 @@ sous tension en hauteur.
 
 <div class="mc-maintenance-record" markdown>
 
-Aucun intervalle d’inspection pancanadien n’a été approuvé. Avant le
-déploiement, consignez un intervalle propre au site et les conditions qui
-déclenchent une inspection supplémentaire, comme des conditions
-météorologiques extrêmes, des travaux à proximité, une infiltration d’eau ou
-un changement du comportement radio.
+Fixez un calendrier d’inspection adapté au site. Inspectez aussi l’installation
+après une tempête, des travaux à proximité, une infiltration d’eau ou un changement
+du comportement radio.
 
 Pour chaque inspection, consignez la date, le nom de la personne qui l’a
 effectuée, les photographies, l’état de la quincaillerie et des câbles, l’état

--- a/docs/hardware/repeater-mounting-options.md
+++ b/docs/hardware/repeater-mounting-options.md
@@ -110,7 +110,7 @@ If anything moves, leaks, loosens, corrodes, changes electrically, or fails its 
 
 <div class="mc-maintenance-record" markdown>
 
-No Canada-wide inspection interval has been approved. Before deployment, record a site-specific interval and the conditions that trigger an extra inspection, such as severe weather, nearby work, water entry, or changed radio behaviour.
+Set an inspection schedule for the site. Inspect again after severe weather, nearby work, water entry, or changed radio behaviour.
 
 Record each inspection date, inspector, photographs, hardware/cable condition, enclosure condition, radio verification, corrective work, and next due date.
 

--- a/docs/hardware/repeater-solar-1w-diy-build.fr.md
+++ b/docs/hardware/repeater-solar-1w-diy-build.fr.md
@@ -39,7 +39,7 @@ facultative, ses mesures et ses limites climatiques n’ont pas été reproduite
 <dl class="mc-guide-facts">
   <div><dt>Radio</dt><dd>GOME Ikoka Stick 0.4.0</dd></div>
   <div><dt>Alimentation</dt><dd>Waveshare Solar Power Manager</dd></div>
-  <div><dt>Micrologiciel</dt><dd>Ni épinglé ni reproduit</dd></div>
+  <div><dt>Micrologiciel</dt><dd>Version non confirmée; fonctionnement non vérifié</dd></div>
   <div><dt>Entretien</dt><dd>À définir pendant l’examen du site</dd></div>
 </dl>
 
@@ -52,7 +52,7 @@ de trafic.
 
 Utilisez le [modèle de 300 mW à l’état d’ébauche](repeater-solar-300mw-diy-build.md)
 ou un système préassemblé examiné, sauf si une personne responsable du réseau
-et une personne responsable de l’examen du matériel et des RF conviennent que
+et une personne qualifiée en électronique et en RF conviennent que
 cette expérience répond à un besoin mesuré.
 
 ## Avant de commencer
@@ -63,8 +63,8 @@ cette expérience répond à un besoin mesuré.
 <ul class="mc-checklist">
   <li>Le besoin du réseau local et les effets sur les autres régions sont documentés.</li>
   <li>Le matériel Ikoka exact et la cible du micrologiciel du répéteur sont confirmés et récupérables par USB.</li>
-  <li>Une personne responsable de l’examen du matériel et de l’électricité approuve la pile, le chargeur, le panneau, le câblage, la protection, la télémétrie facultative et le plan thermique du boîtier.</li>
-  <li>Une personne responsable de l’examen RF approuve la radio, le filtre, la ligne de transmission RF, l’antenne, les connecteurs et le site.</li>
+  <li>Une personne qualifiée en électronique approuve la pile, le chargeur, le panneau, le câblage, la protection, la télémétrie facultative et le plan thermique du boîtier.</li>
+  <li>Une personne qualifiée en RF approuve la radio, le filtre, la ligne de transmission RF, l’antenne, les connecteurs et le site.</li>
   <li>Un examen de la structure et du site couvre la masse finale, la surface du panneau, le montage, le vent, la glace, la neige, le passage des câbles et l’accès.</li>
   <li>La construction restera sous surveillance sur l’établi jusqu’à l’approbation de son dossier d’essai.</li>
 </ul>
@@ -152,7 +152,7 @@ maintien de la pile et la qualité d’impression avant l’utilisation.
   <section class="mc-build-stage" data-stage="stop">
     <h3>Étape 4 — Examiner la modification du démarrage du gestionnaire d’alimentation</h3>
     <p><strong>Ne pontez pas les pastilles du bouton de démarrage du gestionnaire d’alimentation.</strong> Cette modification n’a pas été reproduite ni examinée.</p>
-    <p>Avant d’envisager tout changement, exigez qu’une personne responsable de l’examen du matériel approuve le schéma exact, les modes de défaillance, les répercussions sur la garantie, la méthode de soudage, l’essai de démarrage et le retour en arrière.</p>
+    <p>Avant d’envisager tout changement, exigez qu’une personne qualifiée en électronique approuve le schéma exact, les modes de défaillance, les répercussions sur la garantie, la méthode de soudage, l’essai de démarrage et le retour en arrière.</p>
     <figure><img class="mc-build-photo" src="../images/repeater-solar-1w-diy-build-4.jpg" alt="Pont de fil non vérifié sur les pastilles du bouton de démarrage du gestionnaire solaire" loading="lazy"><figcaption>Modification non vérifiée. Ne la reproduisez pas à partir de cette photographie.</figcaption></figure>
   </section>
   <section class="mc-build-stage" data-stage="stop">
@@ -212,7 +212,7 @@ devinés.
   <li>Consignez les pièces exactes, les révisions, les documents sources, le schéma, les photographies, la polarité et les valeurs mesurées.</li>
   <li>Utilisez des méthodes supervisées de première mise sous tension et de limitation du courant adaptées au matériel examiné.</li>
   <li>Confirmez que l’appareil démarre après l’application de chaque source d’alimentation prévue et après une coupure d’alimentation contrôlée.</li>
-  <li>Confirmez que l’identité, le micrologiciel et les réglages de radio, de région, de parcours, d’annonce et d’accès du répéteur résistent au redémarrage.</li>
+  <li>Confirmez que l’identité, le micrologiciel et les réglages de radio, de région, de parcours, d’annonce et d’accès du répéteur sont conservés après le redémarrage.</li>
   <li>Confirmez qu’un compagnon à proximité reçoit une annonce et que l’essai d’acheminement local prévu réussit.</li>
   <li>Mesurez le comportement RF et électrique avec la méthode approuvée par la personne responsable de l’examen; ne déduisez pas la puissance de sortie à partir d’un seul réglage du micrologiciel.</li>
   <li>Effectuez sous surveillance un essai de recharge et de charge qui couvre les conditions examinées sans dépasser les limites des composants.</li>
@@ -221,7 +221,7 @@ devinés.
 </ul>
 
 Ne déployez pas l’appareil avant qu’une personne responsable de l’examen du
-matériel et de l’électricité, une personne responsable de l’examen RF et le
+matériel et de l’électricité, une personne qualifiée en RF et le
 propriétaire du site aient approuvé le dossier d’essai complet.
 
 ## Récupération et retour en arrière

--- a/docs/hardware/repeater-solar-300mw-diy-build.fr.md
+++ b/docs/hardware/repeater-solar-300mw-diy-build.fr.md
@@ -201,7 +201,7 @@ chargeur, l’appareil de protection, la carte radio et le panneau exacts.
 </ul>
 
 Ne montez pas l’appareil avant qu’il ait réussi toutes les vérifications et
-qu’une personne responsable de l’examen du matériel ait approuvé le dossier du
+qu’une personne qualifiée en électronique ait approuvé le dossier du
 site.
 
 ## Récupération et retour en arrière

--- a/docs/javascripts/community-submission.js
+++ b/docs/javascripts/community-submission.js
@@ -54,12 +54,12 @@ function boundedText(value, maximum, label, required = false, multiline = false)
 }
 
 export function buildCommunityIdea(data) {
-  const category = boundedText(data.category, 80, "Contribution type", true);
-  const experience = boundedText(data.experience, 80, "MeshCore experience", true);
+  const category = boundedText(data.category || "Other community feedback", 80, "Contribution type");
+  const experience = boundedText(data.experience, 80, "MeshCore experience");
   if (!COMMUNITY_CATEGORIES.includes(category)) {
     throw new Error("Choose a valid contribution type.");
   }
-  if (!MESHCORE_EXPERIENCE_LEVELS.includes(experience)) {
+  if (experience && !MESHCORE_EXPERIENCE_LEVELS.includes(experience)) {
     throw new Error("Choose a valid MeshCore experience level.");
   }
   if (data.publicAcknowledged !== true) {
@@ -72,7 +72,7 @@ export function buildCommunityIdea(data) {
     experience,
     summary: boundedText(data.summary, 100, "Short title", true),
     need: boundedText(data.need, 2000, "What is difficult now", true, true),
-    idea: boundedText(data.idea, 2000, "What would help", true, true),
+    idea: boundedText(data.idea, 2000, "What would help", false, true),
     publicAcknowledged: true
   };
   const optional = {
@@ -83,7 +83,17 @@ export function buildCommunityIdea(data) {
   Object.entries(optional).forEach(([key, value]) => {
     if (value) proposal[key] = value;
   });
+  if (data.sourcePage) proposal.sourcePage = normalizeSourcePage(data.sourcePage);
   return proposal;
+}
+
+export function normalizeSourcePage(value) {
+  const url = new URL(value);
+  if (url.origin !== "https://meshcore.ca" || url.username || url.password || url.search ||
+      !/^\/[a-zA-Z0-9/_.-]*$/.test(url.pathname) || !/^(?:#[a-zA-Z0-9_-]+)?$/.test(url.hash) || url.href.length > 400) {
+    throw new Error("Choose a valid source page.");
+  }
+  return url.href;
 }
 
 function section(heading, value, fallback = "Not provided") {
@@ -99,6 +109,7 @@ export function buildSubmissionText(proposal) {
     section("Problem", proposal.need),
     section("Suggested change", proposal.idea),
     section("Additional context", proposal.context),
+    ...(proposal.sourcePage ? [section("Source page", proposal.sourcePage)] : []),
     section(
       "Public contact",
       proposal.followUp,
@@ -135,6 +146,7 @@ export function buildFrenchSubmissionText(proposal) {
     frenchSection("Problème", proposal.need),
     frenchSection("Changement proposé", proposal.idea),
     frenchSection("Autres précisions", proposal.context),
+    ...(proposal.sourcePage ? [frenchSection("Page concernée", proposal.sourcePage)] : []),
     frenchSection(
       "Contact public",
       proposal.followUp,
@@ -148,9 +160,7 @@ export function buildManualGithubLink(
   proposal,
   sourcePage = COMMUNITY_SOURCE_PAGE,
 ) {
-  if (![COMMUNITY_SOURCE_PAGE, COMMUNITY_FRENCH_SOURCE_PAGE].includes(sourcePage)) {
-    throw new Error("Choose a valid source page.");
-  }
+  sourcePage = normalizeSourcePage(proposal.sourcePage || sourcePage);
   const params = new URLSearchParams({
     template: "community_idea.yml",
     title: `[Community idea] ${proposal.summary}`,

--- a/docs/javascripts/submission-form.js
+++ b/docs/javascripts/submission-form.js
@@ -312,6 +312,7 @@
       idea: value("submission-idea"),
       context: value("submission-context"),
       followUp: value("submission-follow-up"),
+      sourcePage: form.elements.source_page.value,
       publicAcknowledged: document.getElementById("submission-public").checked
     };
   }
@@ -422,6 +423,9 @@
       config = await loaded.transport.fetchSubmissionConfig({
         endpoint: loaded.community.COMMUNITY_SUBMISSION_ENDPOINT
       });
+      // The gateway must support the shorter form before it can accept its payload.
+      // Older deployments still offer the copy/GitHub path, without a failed POST.
+      if (!config.communityIdeaOptionalDetails) throw new Error("Submission service update required");
       turnstile = await loaded.transport.loadTurnstile();
       if (widgetId === null) {
         setAntiSpamStatus("Complete the check.");
@@ -577,6 +581,19 @@
   elements.antiSpamRetry.addEventListener("click", initialiseSubmission);
   initialiseCharacterCounters();
   restoreDraft();
+  loadModules().then(function (loaded) {
+    const params = new URLSearchParams(window.location.search);
+    try {
+      if (params.has("source_page")) form.elements.source_page.value = loaded.community.normalizeSourcePage(params.get("source_page"));
+    } catch (_) { /* Ignore malformed context; the form remains usable. */ }
+    const community = params.get("community");
+    if (community && /^[a-z0-9-]{1,80}$/.test(community) && !document.getElementById("submission-context").value) {
+      document.getElementById("submission-context").value = "Community listing: " + community;
+      document.getElementById("submission-category").value = "Regional community information";
+    } else if (params.has("source_page") && !document.getElementById("submission-category").value) {
+      document.getElementById("submission-category").value = "Documentation correction";
+    }
+  }).catch(function () { /* GitHub fallback remains available. */ });
   updateDraftControls();
   updateActions();
 })();

--- a/docs/meshcore/flash-companion.fr.md
+++ b/docs/meshcore/flash-companion.fr.md
@@ -69,9 +69,9 @@ officiel. Il faut un navigateur compatible avec
 2. Sélectionnez le modèle exact de la carte.
 3. Sélectionnez **Companion Radio (Bluetooth)**.
 4. Sélectionnez la version du micrologiciel destinée à cette carte.
-5. Cliquez sur **Enter DFU Mode**. Le programme devrait indiquer qu’il a trouvé un appareil dans le mode attendu.
+5. Suivez les étapes de connexion propres à votre carte. Utilisez **Enter DFU Mode** seulement si cette cible le demande. Le programme devrait indiquer qu’il a trouvé un appareil dans le mode attendu.
 6. Vérifiez de nouveau le matériel et le micrologiciel sélectionnés.
-7. Cliquez sur **Erase Flash**, puis attendez le message confirmant la réussite de l’effacement.
+7. Pour une première installation ou une réinitialisation, sauvegardez d’abord. Cliquez sur **Erase Flash** seulement si les instructions de la carte le demandent. Pour une mise à jour, laissez l’effacement désactivé sauf indication contraire dans les notes de version.
 8. Cliquez sur **Flash** et attendez le message de fin avant de débrancher l’appareil.
 
 ## Récupération en cas d’échec
@@ -105,7 +105,7 @@ sauf si votre méthode d’essai locale exige un autre réglage.
 
 1. Confirmez que l’application se reconnecte et affiche le nom de l’appareil et les réglages radio attendus.
 2. Envoyez un message d’essai dans le canal **Public**.
-3. Une réponse comme **Heard X Repeats** indique qu’au moins un répéteur a signalé l’avoir reçu. Un simple résultat **Sent** ne prouve pas que les réglages sont incorrects; rendez-vous dans une zone où la couverture est connue ou demandez à la communauté locale de vous aider à faire l’essai.
+3. Une réponse comme **Heard X Repeats** indique qu’votre compagnon a entendu une retransmission du message. Un simple résultat **Sent** ne prouve pas que les réglages sont incorrects; rendez-vous dans une zone où la couverture est connue ou demandez à la communauté locale de vous aider à faire l’essai.
 
 La configuration n’est terminée que si les réglages enregistrés résistent à un
 redémarrage et qu’un essai local réussit.

--- a/docs/meshcore/flash-companion.md
+++ b/docs/meshcore/flash-companion.md
@@ -62,9 +62,9 @@ Use the official [MeshCore Web Flasher](https://meshcore.io/flasher). The flashe
 2. Select the exact hardware model.
 3. Select **Companion Radio (Bluetooth)**.
 4. Select the firmware version intended for that board.
-5. Click **Enter DFU Mode**. The flasher should report that it found a device in the expected mode.
+5. Follow the flasher’s connection steps for your board. Use **Enter DFU Mode** only when that target asks for it. The flasher should report that it found a device in the expected mode.
 6. Recheck the hardware and firmware selections.
-7. Click **Erase Flash**, then wait for a successful erase message.
+7. For a first installation or deliberate reset, back up first. Click **Erase Flash** only if the board’s instructions require it. For an update, leave erase off unless its release notes require a reset.
 8. Click **Flash** and wait for the completion message before disconnecting the device.
 
 ## Recovery if flashing fails
@@ -89,7 +89,7 @@ The optional **Message Settings → Auto Reset Path** preference affects how the
 
 1. Confirm the app reconnects and shows the expected device name and radio settings.
 2. Send a test message in the **Public** channel.
-3. A response such as **Heard X Repeats** indicates that at least one repeater reported hearing it. A plain **Sent** result is not proof that the settings are wrong; move to a known coverage area or ask the local community to help test.
+3. A response such as **Heard X Repeats** indicates that your companion heard a rebroadcast of the message. A plain **Sent** result is not proof that the settings are wrong; move to a known coverage area or ask the local community to help test.
 
 Do not consider the setup complete until the saved settings survive a reboot and a local test succeeds.
 

--- a/docs/meshcore/flash-repeater.fr.md
+++ b/docs/meshcore/flash-repeater.fr.md
@@ -21,7 +21,7 @@ page_styles:
   - assets/styles/devices-builds.css?v=20260728-1
   - assets/styles/repeater-hash-check.css?v=20260820-1
 page_scripts:
-  - assets/javascripts/repeater-hash-check.js?v=20260820-1
+  - assets/javascripts/repeater-hash-check.js?v=20260904-1
 ---
 # Programmer, configurer et tester un répéteur sur l’établi
 
@@ -89,7 +89,7 @@ guide ou d’une capture d’écran.
 3. Activez son mode de chargeur d’amorçage UF2. Sur une RAK4631, il faut normalement appuyer deux fois sur le bouton près du port USB; pour les autres cartes, utilisez la méthode de réinitialisation documentée.
 4. Confirmez qu’un lecteur USB apparaît et examinez `INFO.TXT` pour vérifier l’identité de la carte.
 5. Copiez le fichier UF2 correspondant sur ce lecteur. Le lecteur peut se déconnecter pendant le redémarrage de la carte.
-6. Revenez au mode de chargeur d’amorçage et confirmez que `INFO.TXT` indique la version `0.9.2` avant de continuer.
+6. Revenez au mode de chargeur d’amorçage et confirmez que `INFO.TXT` indique la carte et la version du chargeur d’amorçage correspondant à la version choisie avant de continuer.
 
 Si l’identité de la carte ou la version attendue ne correspond pas, arrêtez et
 récupérez l’appareil par USB avant de programmer MeshCore.
@@ -103,9 +103,9 @@ officiel dans un navigateur compatible avec
 1. Branchez le répéteur par USB.
 2. Sélectionnez le modèle exact du matériel.
 3. Sélectionnez **Repeater** comme rôle et choisissez la version destinée à cette carte.
-4. Cliquez sur **Enter DFU Mode** et attendez que le programme trouve la carte.
+4. Suivez les étapes de connexion propres à votre carte. Utilisez **Enter DFU Mode** seulement si cette cible le demande.
 5. Vérifiez de nouveau la carte et le rôle sélectionnés.
-6. Cliquez sur **Erase Flash** et attendez le message confirmant la réussite de l’effacement.
+6. Pour une première installation ou une réinitialisation, sauvegardez d’abord. Cliquez sur **Erase Flash** seulement si les instructions de la carte le demandent. Pour une mise à jour, laissez l’effacement désactivé sauf indication contraire dans les notes de version.
 7. Cliquez sur **Flash** et attendez la fin de l’opération avant de débrancher l’appareil.
 
 Si la programmation échoue après l’effacement, n’effacez pas l’appareil à

--- a/docs/meshcore/flash-repeater.md
+++ b/docs/meshcore/flash-repeater.md
@@ -21,7 +21,7 @@ page_styles:
   - assets/styles/devices-builds.css?v=20260728-1
   - assets/styles/repeater-hash-check.css?v=20260820-1
 page_scripts:
-  - assets/javascripts/repeater-hash-check.js?v=20260820-1
+  - assets/javascripts/repeater-hash-check.js?v=20260904-1
 ---
 # Flash, configure, and bench-test a repeater
 
@@ -54,7 +54,7 @@ Never post the private key or passwords in an issue, screenshot, log, or chat. I
 
 ## What flashing changes
 
-An erase replaces firmware and can delete identity and settings. The setup also writes radio, advert, path-hash, access, location, and region values that affect the shared network.
+Flashing replaces firmware. Erasing can also delete identity and settings. The setup also writes radio, advert, path-hash, access, location, and region values that affect the shared network.
 
 ## Recovery plan
 
@@ -74,7 +74,7 @@ hardware. Do not use a filename copied from an older guide or screenshot.
 3. Enter its UF2 bootloader mode. On a RAK4631 this is normally done by double-pressing the button beside USB; other boards use their documented reset method.
 4. Confirm a USB drive appears and inspect `INFO.TXT` so the board identity is what you expect.
 5. Copy the matching UF2 file to that drive. The drive may disconnect as the board reboots.
-6. Re-enter bootloader mode and confirm `INFO.TXT` reports bootloader version `0.9.2` before continuing.
+6. Re-enter bootloader mode and confirm `INFO.TXT` reports the board and bootloader version from the release you selected before continuing.
 
 If the board identity or expected version does not match, stop and recover over USB before flashing MeshCore.
 
@@ -85,9 +85,9 @@ Use the official [MeshCore Web Flasher](https://meshcore.io/flasher) in a browse
 1. Connect the repeater by USB.
 2. Select the exact hardware model.
 3. Select **Repeater** as the role and choose the intended version for that board.
-4. Click **Enter DFU Mode** and wait for the flasher to find the board.
+4. Follow the flasher’s connection steps for your board. Use **Enter DFU Mode** only when that target asks for it.
 5. Recheck the selected board and role.
-6. Click **Erase Flash** and wait for a successful erase message.
+6. For a first installation or deliberate reset, back up first. Click **Erase Flash** only if the board’s instructions require it. For an update, leave erase off unless its release notes require a reset.
 7. Click **Flash** and wait for completion before disconnecting.
 
 If flashing fails after erase, do not repeatedly erase. Refresh the page, return the board to DFU mode, verify the target again, and retry **Flash**. Use the board's USB recovery process if it no longer appears.

--- a/docs/meshcore/flash-room-server.fr.md
+++ b/docs/meshcore/flash-room-server.fr.md
@@ -67,9 +67,9 @@ n’utilisez pas les fichiers d’une autre carte.
 1. Ouvrez le [programme de mise à jour Web MeshCore](https://meshcore.io/flasher) officiel.
 2. Sélectionnez le modèle exact de l’appareil.
 3. Sélectionnez **Room Server** et la version destinée à cette carte.
-4. Cliquez sur **Enter DFU Mode** et attendez que l’appareil attendu apparaisse.
+4. Suivez les étapes de connexion propres à votre carte. Utilisez **Enter DFU Mode** seulement si cette cible le demande.
 5. Vérifiez de nouveau le matériel et le rôle sélectionnés.
-6. Cliquez sur **Erase Flash** et attendez le message confirmant la réussite de l’effacement.
+6. Pour une première installation ou une réinitialisation, sauvegardez d’abord. Cliquez sur **Erase Flash** seulement si les instructions de la carte le demandent. Pour une mise à jour, laissez l’effacement désactivé sauf indication contraire dans les notes de version.
 7. Cliquez sur **Flash** et attendez la fin de l’opération avant de débrancher l’appareil.
 
 Si la programmation échoue après l’effacement, laissez l’appareil branché,

--- a/docs/meshcore/flash-room-server.md
+++ b/docs/meshcore/flash-room-server.md
@@ -54,9 +54,9 @@ Keep the exact board's USB recovery method, backed-up identity/settings, a known
 1. Open the official [MeshCore Web Flasher](https://meshcore.io/flasher).
 2. Select the exact device model.
 3. Select **Room Server** and the intended version for that board.
-4. Click **Enter DFU Mode** and wait for the expected device to appear.
+4. Follow the flasher’s connection steps for your board. Use **Enter DFU Mode** only when that target asks for it.
 5. Recheck the hardware and role selections.
-6. Click **Erase Flash** and wait for a successful erase message.
+6. For a first installation or deliberate reset, back up first. Click **Erase Flash** only if the board’s instructions require it. For an update, leave erase off unless its release notes require a reset.
 7. Click **Flash** and wait for completion before disconnecting.
 
 If flashing fails after erase, leave the device connected, refresh the flasher, re-enter DFU mode, confirm the board and role, and retry **Flash**. Use the board's documented USB recovery process if it is no longer detected.

--- a/docs/meshcore/general-faq.fr.md
+++ b/docs/meshcore/general-faq.fr.md
@@ -34,8 +34,8 @@ source actuelle.
 
 ### Quels réglages radio dois-je utiliser au Canada?
 
-Pour un répéteur, utilisez le [configurateur de répéteur](../config/index.md). Il
-fournit les réglages actuels pour l’emplacement choisi.
+Utilisez le profil radio de votre communauté. Le [configurateur de répéteur](../config/index.md)
+trouve les chemins régionaux, mais conserve les réglages radio tant que vous ne choisissez pas de profil.
 
 Quel que soit le rôle de l’appareil, consultez d’abord le
 [répertoire des communautés](../provinces/index.md). Lorsqu’une communauté
@@ -43,10 +43,10 @@ publie des réglages locaux différents, suivez-les.
 
 ### Qu’est-ce que le mode de hachage des parcours?
 
-Il détermine la taille des identifiants utilisés dans les parcours d’annonce.
-La norme canadienne des régions et le configurateur fournissent le réglage
-actuel d’un répéteur. Utilisez leur résultat plutôt que de copier une ancienne
-commande provenant d’une discussion ou d’une capture d’écran.
+Il détermine la taille des identifiants dans les parcours d’annonce : 1, 2 ou 3 octets.
+MeshCore Canada recommande 3 octets pour réduire les collisions. Les versions 1.14
+et suivantes peuvent relayer des parcours de tailles différentes; les nœuds voisins
+n’ont pas tous besoin d’utiliser la même taille d’identifiant.
 
 [Lire la norme des régions](../config/standard.md).
 

--- a/docs/meshcore/general-faq.md
+++ b/docs/meshcore/general-faq.md
@@ -34,18 +34,17 @@ of repeating values that may change.
 
 ### Which radio settings should I use in Canada?
 
-Use the [repeater configurator](../config/index.md) for a repeater. It returns
-the current settings for the location you select.
+Use your community’s radio profile. The [repeater configurator](../config/index.md)
+finds region paths, but keeps your radio settings unless you choose a profile.
 
 For any role, first check the [community directory](../provinces/index.md).
 Follow a published local override when one exists.
 
 ### What is path hash mode?
 
-It controls the size of the identifiers used in advert paths. The Canadian
-region standard and configurator provide the current setting for a repeater.
-Use their output instead of copying an old command from a discussion or
-screenshot.
+It sets the size of the identifiers in this node’s advert paths: 1, 2, or 3 bytes.
+MeshCore Canada recommends 3 bytes to reduce collisions. Firmware 1.14 and newer
+can forward mixed sizes; neighbouring nodes do not all need the same ID size.
 
 [Read the region standard](../config/standard.md).
 

--- a/docs/meshcore/general-howto.fr.md
+++ b/docs/meshcore/general-howto.fr.md
@@ -20,6 +20,7 @@ destructive: false
 Choisissez une tâche. Les captures montrent une version de l’application mobile
 MeshCore; les libellés et leur emplacement peuvent différer.
 
+- [Envoyer votre premier message](#send-your-first-message)
 - [Partager votre lien de contact](#share-your-contact-link)
 - [Importer un lien de contact](#import-a-contact-link)
 - [Tracer un parcours](#trace-a-path)
@@ -35,6 +36,16 @@ MeshCore; les libellés et leur emplacement peuvent différer.
   précis dans une capture d’écran partagée.
 
 </div>
+
+## Envoyer votre premier message { #send-your-first-message }
+
+1. Connectez l’application à votre compagnon et confirmez les réglages radio locaux.
+2. Ouvrez le canal de votre communauté ou choisissez un contact importé.
+3. Envoyez une courte salutation et demandez une réponse.
+
+Une réponse confirme la communication dans les deux sens. L’indicateur d’envoi
+ne suffit pas à confirmer la réception. Sans réponse, vérifiez avec une personne
+à proximité avant d’envoyer d’autres essais.
 
 ## Partager votre lien de contact { #share-your-contact-link }
 

--- a/docs/meshcore/general-howto.md
+++ b/docs/meshcore/general-howto.md
@@ -20,6 +20,7 @@ destructive: false
 Choose a task. The screenshots show one version of the MeshCore mobile app, so
 labels and positions may differ.
 
+- [Send your first message](#send-your-first-message)
 - [Share your contact link](#share-your-contact-link)
 - [Import a contact link](#import-a-contact-link)
 - [Trace a path](#trace-a-path)
@@ -35,6 +36,15 @@ labels and positions may differ.
   screenshot.
 
 </div>
+
+## Send your first message
+
+1. Connect the app to your companion and confirm the local radio settings.
+2. Open the channel used by your community, or choose an imported contact.
+3. Send a short greeting and ask for a reply.
+
+A reply confirms two-way communication. A sent indicator alone does not confirm
+delivery. If nobody replies, check with a nearby operator before sending more tests.
 
 ## Share your contact link
 

--- a/docs/meshcore/generate-repeater-id.fr.md
+++ b/docs/meshcore/generate-repeater-id.fr.md
@@ -22,7 +22,7 @@ page_styles:
   - assets/styles/devices-builds.css?v=20260728-1
   - assets/styles/repeater-hash-check.css?v=20260820-1
 page_scripts:
-  - assets/javascripts/repeater-hash-check.js?v=20260820-1
+  - assets/javascripts/repeater-hash-check.js?v=20260904-1
 ---
 # Changer l’identifiant d’un répéteur en mode 1 octet
 

--- a/docs/meshcore/generate-repeater-id.md
+++ b/docs/meshcore/generate-repeater-id.md
@@ -22,7 +22,7 @@ page_styles:
   - assets/styles/devices-builds.css?v=20260728-1
   - assets/styles/repeater-hash-check.css?v=20260820-1
 page_scripts:
-  - assets/javascripts/repeater-hash-check.js?v=20260820-1
+  - assets/javascripts/repeater-hash-check.js?v=20260904-1
 ---
 # Change a repeater ID in 1-byte mode
 

--- a/docs/privacy.fr.md
+++ b/docs/privacy.fr.md
@@ -43,6 +43,13 @@ limitation du débit. Aucune période de conservation n’a encore été publié
 
 ## Données enregistrées sur votre appareil
 
+Changer de langue ou passer entre la carte et le configurateur conserve votre
+sélection dans l’URL de destination. Elle peut contenir les coordonnées saisies,
+un lieu, des chemins régionaux et un profil radio. Ces URL peuvent apparaître dans
+l’historique du navigateur et les journaux du serveur. Ne partagez pas un lien qui
+contient un emplacement privé. Les résumés téléchargés omettent les coordonnées
+exactes et les identifiants de connexion.
+
 Les listes de configuration, les brouillons d’idées et le dernier code de
 région Beacon choisi dans l’outil de vérification sont enregistrés uniquement
 dans votre navigateur lorsque vous utilisez ces fonctions. Les clés publiques

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -42,6 +42,12 @@ period has not yet been published.
 
 ## Saved on your device
 
+Switching language or moving between the region map and configurator carries your
+selection in the destination URL. This can include entered coordinates, a location
+label, region paths, and radio-profile choices. These URLs may appear in browser
+history and server access logs. Do not share a link containing a private location.
+Downloaded setup summaries omit exact coordinates and credentials.
+
 Setup checklists, idea drafts, and the last Beacon region code selected in the
 repeater-ID checker are saved in your browser only when you use those features.
 Repeater public keys, passwords, private keys, anti-spam tokens, and location

--- a/docs/provinces/alberta.fr.md
+++ b/docs/provinces/alberta.fr.md
@@ -39,7 +39,7 @@ sauf si une fiche indique des réglages locaux différents.
 <dl class="mc-community-facts">
 <div><dt>Réglages</dt>
 <dd>Réglages par défaut du Canada</dd></div>
-<div><dt>Dernière vérification</dt>
+<div><dt>Fiche révisée</dt>
 <dd>2026-08-29</dd></div>
 </dl>
 <h4>Coordonnées</h4>
@@ -56,7 +56,7 @@ sauf si une fiche indique des réglages locaux différents.
 <p class="mc-community-contact-health">
 <strong>Vérification :</strong> Effectuée le 2026-08-29
 </p>
-<p class="mc-community-card__action"><a href="../../submit-idea/">Mettre cette fiche à jour</a></p>
+<p class="mc-community-card__action"><a href="../../submit-idea/?community=alberta-meshcore-networks&amp;source_page=https%3A%2F%2Fmeshcore.ca%2Ffr%2Fprovinces%2Falberta%2F%23community-alberta-meshcore-networks">Mettre cette fiche à jour</a></p>
 </article>
 <article class="mc-community-card mc-community-card--detail" id="community-airdrie-meshcore-network">
 <div class="mc-community-card__header">
@@ -68,7 +68,7 @@ sauf si une fiche indique des réglages locaux différents.
 <dl class="mc-community-facts">
 <div><dt>Réglages</dt>
 <dd>Réglages par défaut du Canada</dd></div>
-<div><dt>Dernière vérification</dt>
+<div><dt>Fiche révisée</dt>
 <dd>2026-08-29</dd></div>
 </dl>
 <h4>Coordonnées</h4>
@@ -82,7 +82,7 @@ sauf si une fiche indique des réglages locaux différents.
 <p class="mc-community-contact-health">
 <strong>Vérification :</strong> Effectuée le 2026-08-29
 </p>
-<p class="mc-community-card__action"><a href="../../submit-idea/">Mettre cette fiche à jour</a></p>
+<p class="mc-community-card__action"><a href="../../submit-idea/?community=airdrie-meshcore-network&amp;source_page=https%3A%2F%2Fmeshcore.ca%2Ffr%2Fprovinces%2Falberta%2F%23community-airdrie-meshcore-network">Mettre cette fiche à jour</a></p>
 </article>
 <article class="mc-community-card mc-community-card--detail" id="community-calgary-area-meshcore">
 <div class="mc-community-card__header">
@@ -93,7 +93,7 @@ sauf si une fiche indique des réglages locaux différents.
 <dl class="mc-community-facts">
 <div><dt>Réglages</dt>
 <dd>Réglages par défaut du Canada</dd></div>
-<div><dt>Dernière vérification</dt>
+<div><dt>Fiche révisée</dt>
 <dd>2026-08-29</dd></div>
 </dl>
 <h4>Coordonnées</h4>
@@ -104,7 +104,7 @@ sauf si une fiche indique des réglages locaux différents.
 <p class="mc-community-contact-health">
 <strong>Vérification :</strong> Certains liens restent à vérifier
 </p>
-<p class="mc-community-card__action"><a href="../../submit-idea/">Mettre cette fiche à jour</a></p>
+<p class="mc-community-card__action"><a href="../../submit-idea/?community=calgary-area-meshcore&amp;source_page=https%3A%2F%2Fmeshcore.ca%2Ffr%2Fprovinces%2Falberta%2F%23community-calgary-area-meshcore">Mettre cette fiche à jour</a></p>
 </article>
 <article class="mc-community-card mc-community-card--detail" id="community-calgary-meshcore-network">
 <div class="mc-community-card__header">
@@ -116,7 +116,7 @@ sauf si une fiche indique des réglages locaux différents.
 <dl class="mc-community-facts">
 <div><dt>Réglages</dt>
 <dd>Réglages par défaut du Canada</dd></div>
-<div><dt>Dernière vérification</dt>
+<div><dt>Fiche révisée</dt>
 <dd>2026-08-29</dd></div>
 </dl>
 <h4>Coordonnées</h4>
@@ -130,7 +130,7 @@ sauf si une fiche indique des réglages locaux différents.
 <p class="mc-community-contact-health">
 <strong>Vérification :</strong> Effectuée le 2026-08-29
 </p>
-<p class="mc-community-card__action"><a href="../../submit-idea/">Mettre cette fiche à jour</a></p>
+<p class="mc-community-card__action"><a href="../../submit-idea/?community=calgary-meshcore-network&amp;source_page=https%3A%2F%2Fmeshcore.ca%2Ffr%2Fprovinces%2Falberta%2F%23community-calgary-meshcore-network">Mettre cette fiche à jour</a></p>
 </article>
 <article class="mc-community-card mc-community-card--detail" id="community-edmonton-meshcore-network">
 <div class="mc-community-card__header">
@@ -142,7 +142,7 @@ sauf si une fiche indique des réglages locaux différents.
 <dl class="mc-community-facts">
 <div><dt>Réglages</dt>
 <dd>Réglages par défaut du Canada</dd></div>
-<div><dt>Dernière vérification</dt>
+<div><dt>Fiche révisée</dt>
 <dd>2026-08-29</dd></div>
 </dl>
 <h4>Coordonnées</h4>
@@ -155,7 +155,7 @@ sauf si une fiche indique des réglages locaux différents.
 <p class="mc-community-contact-health">
 <strong>Vérification :</strong> Effectuée le 2026-08-29
 </p>
-<p class="mc-community-card__action"><a href="../../submit-idea/">Mettre cette fiche à jour</a></p>
+<p class="mc-community-card__action"><a href="../../submit-idea/?community=edmonton-meshcore-network&amp;source_page=https%3A%2F%2Fmeshcore.ca%2Ffr%2Fprovinces%2Falberta%2F%23community-edmonton-meshcore-network">Mettre cette fiche à jour</a></p>
 </article>
 <article class="mc-community-card mc-community-card--detail" id="community-yegmesh-ca">
 <div class="mc-community-card__header">
@@ -167,7 +167,7 @@ sauf si une fiche indique des réglages locaux différents.
 <dl class="mc-community-facts">
 <div><dt>Réglages</dt>
 <dd>Réglages par défaut du Canada</dd></div>
-<div><dt>Dernière vérification</dt>
+<div><dt>Fiche révisée</dt>
 <dd>2026-08-29</dd></div>
 </dl>
 <h4>Coordonnées</h4>
@@ -180,7 +180,7 @@ sauf si une fiche indique des réglages locaux différents.
 <p class="mc-community-contact-health">
 <strong>Vérification :</strong> Effectuée le 2026-08-29
 </p>
-<p class="mc-community-card__action"><a href="../../submit-idea/">Mettre cette fiche à jour</a></p>
+<p class="mc-community-card__action"><a href="../../submit-idea/?community=yegmesh-ca&amp;source_page=https%3A%2F%2Fmeshcore.ca%2Ffr%2Fprovinces%2Falberta%2F%23community-yegmesh-ca">Mettre cette fiche à jour</a></p>
 </article>
 <article class="mc-community-card mc-community-card--detail" id="community-yqlmesh">
 <div class="mc-community-card__header">
@@ -192,7 +192,7 @@ sauf si une fiche indique des réglages locaux différents.
 <dl class="mc-community-facts">
 <div><dt>Réglages</dt>
 <dd>Réglages par défaut du Canada</dd></div>
-<div><dt>Dernière vérification</dt>
+<div><dt>Fiche révisée</dt>
 <dd>2026-08-29</dd></div>
 </dl>
 <h4>Coordonnées</h4>
@@ -209,7 +209,7 @@ sauf si une fiche indique des réglages locaux différents.
 <p class="mc-community-contact-health">
 <strong>Vérification :</strong> Certains liens restent à vérifier
 </p>
-<p class="mc-community-card__action"><a href="../../submit-idea/">Mettre cette fiche à jour</a></p>
+<p class="mc-community-card__action"><a href="../../submit-idea/?community=yqlmesh&amp;source_page=https%3A%2F%2Fmeshcore.ca%2Ffr%2Fprovinces%2Falberta%2F%23community-yqlmesh">Mettre cette fiche à jour</a></p>
 </article>
 <article class="mc-community-card mc-community-card--detail" id="community-southern-alberta">
 <div class="mc-community-card__header">
@@ -220,7 +220,7 @@ sauf si une fiche indique des réglages locaux différents.
 <dl class="mc-community-facts">
 <div><dt>Réglages</dt>
 <dd>Réglages par défaut du Canada</dd></div>
-<div><dt>Dernière vérification</dt>
+<div><dt>Fiche révisée</dt>
 <dd>2026-08-29</dd></div>
 </dl>
 <h4>Coordonnées</h4>
@@ -231,7 +231,7 @@ sauf si une fiche indique des réglages locaux différents.
 <p class="mc-community-contact-health">
 <strong>Vérification :</strong> Certains liens restent à vérifier
 </p>
-<p class="mc-community-card__action"><a href="../../submit-idea/">Mettre cette fiche à jour</a></p>
+<p class="mc-community-card__action"><a href="../../submit-idea/?community=southern-alberta&amp;source_page=https%3A%2F%2Fmeshcore.ca%2Ffr%2Fprovinces%2Falberta%2F%23community-southern-alberta">Mettre cette fiche à jour</a></p>
 </article>
 <article class="mc-community-card mc-community-card--detail" id="community-yyc-meshcore-discord">
 <div class="mc-community-card__header">
@@ -242,7 +242,7 @@ sauf si une fiche indique des réglages locaux différents.
 <dl class="mc-community-facts">
 <div><dt>Réglages</dt>
 <dd>Réglages par défaut du Canada</dd></div>
-<div><dt>Dernière vérification</dt>
+<div><dt>Fiche révisée</dt>
 <dd>2026-08-29</dd></div>
 </dl>
 <h4>Coordonnées</h4>
@@ -253,7 +253,7 @@ sauf si une fiche indique des réglages locaux différents.
 <p class="mc-community-contact-health">
 <strong>Vérification :</strong> Effectuée le 2026-08-29
 </p>
-<p class="mc-community-card__action"><a href="../../submit-idea/">Mettre cette fiche à jour</a></p>
+<p class="mc-community-card__action"><a href="../../submit-idea/?community=yyc-meshcore-discord&amp;source_page=https%3A%2F%2Fmeshcore.ca%2Ffr%2Fprovinces%2Falberta%2F%23community-yyc-meshcore-discord">Mettre cette fiche à jour</a></p>
 </article>
 </div>
 

--- a/docs/provinces/alberta.md
+++ b/docs/provinces/alberta.md
@@ -39,7 +39,7 @@ card lists different local settings.
 <dl class="mc-community-facts">
 <div><dt>Settings</dt>
 <dd>Uses the Canada defaults</dd></div>
-<div><dt>Last verified</dt>
+<div><dt>Listing reviewed</dt>
 <dd>2026-08-29</dd></div>
 </dl>
 <h4>Contacts</h4>
@@ -54,9 +54,9 @@ card lists different local settings.
 <li><strong>Website:</strong> <a href="https://albertamesh.ca/monitoring-tools/" rel="noopener">Monitoring tools</a> <span class="mc-community-external">(external)</span></li>
 </ul>
 <p class="mc-community-contact-health">
-<strong>Contact check:</strong> Verified on 2026-08-29
+<strong>Contact check:</strong> Links checked on 2026-08-29
 </p>
-<p class="mc-community-card__action"><a href="../../submit-idea/">Update this listing</a></p>
+<p class="mc-community-card__action"><a href="../../submit-idea/?community=alberta-meshcore-networks&amp;source_page=https%3A%2F%2Fmeshcore.ca%2Fprovinces%2Falberta%2F%23community-alberta-meshcore-networks">Update this listing</a></p>
 </article>
 <article class="mc-community-card mc-community-card--detail" id="community-airdrie-meshcore-network">
 <div class="mc-community-card__header">
@@ -68,7 +68,7 @@ card lists different local settings.
 <dl class="mc-community-facts">
 <div><dt>Settings</dt>
 <dd>Uses the Canada defaults</dd></div>
-<div><dt>Last verified</dt>
+<div><dt>Listing reviewed</dt>
 <dd>2026-08-29</dd></div>
 </dl>
 <h4>Contacts</h4>
@@ -80,9 +80,9 @@ card lists different local settings.
 <li><strong>Website:</strong> <a href="https://waev.app/#/live-map/@51.28107,-113.99966,14.47z" rel="noopener">WAeV live map</a> <span class="mc-community-external">(external)</span></li>
 </ul>
 <p class="mc-community-contact-health">
-<strong>Contact check:</strong> Verified on 2026-08-29
+<strong>Contact check:</strong> Links checked on 2026-08-29
 </p>
-<p class="mc-community-card__action"><a href="../../submit-idea/">Update this listing</a></p>
+<p class="mc-community-card__action"><a href="../../submit-idea/?community=airdrie-meshcore-network&amp;source_page=https%3A%2F%2Fmeshcore.ca%2Fprovinces%2Falberta%2F%23community-airdrie-meshcore-network">Update this listing</a></p>
 </article>
 <article class="mc-community-card mc-community-card--detail" id="community-calgary-area-meshcore">
 <div class="mc-community-card__header">
@@ -93,7 +93,7 @@ card lists different local settings.
 <dl class="mc-community-facts">
 <div><dt>Settings</dt>
 <dd>Uses the Canada defaults</dd></div>
-<div><dt>Last verified</dt>
+<div><dt>Listing reviewed</dt>
 <dd>2026-08-29</dd></div>
 </dl>
 <h4>Contacts</h4>
@@ -104,7 +104,7 @@ card lists different local settings.
 <p class="mc-community-contact-health">
 <strong>Contact check:</strong> Some links still need review
 </p>
-<p class="mc-community-card__action"><a href="../../submit-idea/">Update this listing</a></p>
+<p class="mc-community-card__action"><a href="../../submit-idea/?community=calgary-area-meshcore&amp;source_page=https%3A%2F%2Fmeshcore.ca%2Fprovinces%2Falberta%2F%23community-calgary-area-meshcore">Update this listing</a></p>
 </article>
 <article class="mc-community-card mc-community-card--detail" id="community-calgary-meshcore-network">
 <div class="mc-community-card__header">
@@ -116,7 +116,7 @@ card lists different local settings.
 <dl class="mc-community-facts">
 <div><dt>Settings</dt>
 <dd>Uses the Canada defaults</dd></div>
-<div><dt>Last verified</dt>
+<div><dt>Listing reviewed</dt>
 <dd>2026-08-29</dd></div>
 </dl>
 <h4>Contacts</h4>
@@ -128,9 +128,9 @@ card lists different local settings.
 <li><strong>Website:</strong> <a href="https://albertamesh.ca/calgary/#rx-channels" rel="noopener">Recommended Calgary RX channels</a> <span class="mc-community-external">(external)</span></li>
 </ul>
 <p class="mc-community-contact-health">
-<strong>Contact check:</strong> Verified on 2026-08-29
+<strong>Contact check:</strong> Links checked on 2026-08-29
 </p>
-<p class="mc-community-card__action"><a href="../../submit-idea/">Update this listing</a></p>
+<p class="mc-community-card__action"><a href="../../submit-idea/?community=calgary-meshcore-network&amp;source_page=https%3A%2F%2Fmeshcore.ca%2Fprovinces%2Falberta%2F%23community-calgary-meshcore-network">Update this listing</a></p>
 </article>
 <article class="mc-community-card mc-community-card--detail" id="community-edmonton-meshcore-network">
 <div class="mc-community-card__header">
@@ -142,7 +142,7 @@ card lists different local settings.
 <dl class="mc-community-facts">
 <div><dt>Settings</dt>
 <dd>Uses the Canada defaults</dd></div>
-<div><dt>Last verified</dt>
+<div><dt>Listing reviewed</dt>
 <dd>2026-08-29</dd></div>
 </dl>
 <h4>Contacts</h4>
@@ -153,9 +153,9 @@ card lists different local settings.
 <li><strong>MeshMapper:</strong> <a href="https://yeg.meshmapper.net/?lat=53.45752&amp;lon=-113.58320&amp;zoom=10.03" rel="noopener">Edmonton network map</a> <span class="mc-community-external">(external)</span></li>
 </ul>
 <p class="mc-community-contact-health">
-<strong>Contact check:</strong> Verified on 2026-08-29
+<strong>Contact check:</strong> Links checked on 2026-08-29
 </p>
-<p class="mc-community-card__action"><a href="../../submit-idea/">Update this listing</a></p>
+<p class="mc-community-card__action"><a href="../../submit-idea/?community=edmonton-meshcore-network&amp;source_page=https%3A%2F%2Fmeshcore.ca%2Fprovinces%2Falberta%2F%23community-edmonton-meshcore-network">Update this listing</a></p>
 </article>
 <article class="mc-community-card mc-community-card--detail" id="community-yegmesh-ca">
 <div class="mc-community-card__header">
@@ -167,7 +167,7 @@ card lists different local settings.
 <dl class="mc-community-facts">
 <div><dt>Settings</dt>
 <dd>Uses the Canada defaults</dd></div>
-<div><dt>Last verified</dt>
+<div><dt>Listing reviewed</dt>
 <dd>2026-08-29</dd></div>
 </dl>
 <h4>Contacts</h4>
@@ -178,9 +178,9 @@ card lists different local settings.
 <li><strong>MeshMapper:</strong> <a href="https://yeg.meshmapper.net/?lat=53.45752&amp;lon=-113.58320&amp;zoom=10.03" rel="noopener">Edmonton network map</a> <span class="mc-community-external">(external)</span></li>
 </ul>
 <p class="mc-community-contact-health">
-<strong>Contact check:</strong> Verified on 2026-08-29
+<strong>Contact check:</strong> Links checked on 2026-08-29
 </p>
-<p class="mc-community-card__action"><a href="../../submit-idea/">Update this listing</a></p>
+<p class="mc-community-card__action"><a href="../../submit-idea/?community=yegmesh-ca&amp;source_page=https%3A%2F%2Fmeshcore.ca%2Fprovinces%2Falberta%2F%23community-yegmesh-ca">Update this listing</a></p>
 </article>
 <article class="mc-community-card mc-community-card--detail" id="community-yqlmesh">
 <div class="mc-community-card__header">
@@ -192,7 +192,7 @@ card lists different local settings.
 <dl class="mc-community-facts">
 <div><dt>Settings</dt>
 <dd>Uses the Canada defaults</dd></div>
-<div><dt>Last verified</dt>
+<div><dt>Listing reviewed</dt>
 <dd>2026-08-29</dd></div>
 </dl>
 <h4>Contacts</h4>
@@ -209,7 +209,7 @@ card lists different local settings.
 <p class="mc-community-contact-health">
 <strong>Contact check:</strong> Some links still need review
 </p>
-<p class="mc-community-card__action"><a href="../../submit-idea/">Update this listing</a></p>
+<p class="mc-community-card__action"><a href="../../submit-idea/?community=yqlmesh&amp;source_page=https%3A%2F%2Fmeshcore.ca%2Fprovinces%2Falberta%2F%23community-yqlmesh">Update this listing</a></p>
 </article>
 <article class="mc-community-card mc-community-card--detail" id="community-southern-alberta">
 <div class="mc-community-card__header">
@@ -220,7 +220,7 @@ card lists different local settings.
 <dl class="mc-community-facts">
 <div><dt>Settings</dt>
 <dd>Uses the Canada defaults</dd></div>
-<div><dt>Last verified</dt>
+<div><dt>Listing reviewed</dt>
 <dd>2026-08-29</dd></div>
 </dl>
 <h4>Contacts</h4>
@@ -231,7 +231,7 @@ card lists different local settings.
 <p class="mc-community-contact-health">
 <strong>Contact check:</strong> Some links still need review
 </p>
-<p class="mc-community-card__action"><a href="../../submit-idea/">Update this listing</a></p>
+<p class="mc-community-card__action"><a href="../../submit-idea/?community=southern-alberta&amp;source_page=https%3A%2F%2Fmeshcore.ca%2Fprovinces%2Falberta%2F%23community-southern-alberta">Update this listing</a></p>
 </article>
 <article class="mc-community-card mc-community-card--detail" id="community-yyc-meshcore-discord">
 <div class="mc-community-card__header">
@@ -242,7 +242,7 @@ card lists different local settings.
 <dl class="mc-community-facts">
 <div><dt>Settings</dt>
 <dd>Uses the Canada defaults</dd></div>
-<div><dt>Last verified</dt>
+<div><dt>Listing reviewed</dt>
 <dd>2026-08-29</dd></div>
 </dl>
 <h4>Contacts</h4>
@@ -251,9 +251,9 @@ card lists different local settings.
 <li><strong>Website:</strong> <a href="https://meshmonitoring.com/" rel="noopener">MeshMonitoring</a> <span class="mc-community-external">(external)</span></li>
 </ul>
 <p class="mc-community-contact-health">
-<strong>Contact check:</strong> Verified on 2026-08-29
+<strong>Contact check:</strong> Links checked on 2026-08-29
 </p>
-<p class="mc-community-card__action"><a href="../../submit-idea/">Update this listing</a></p>
+<p class="mc-community-card__action"><a href="../../submit-idea/?community=yyc-meshcore-discord&amp;source_page=https%3A%2F%2Fmeshcore.ca%2Fprovinces%2Falberta%2F%23community-yyc-meshcore-discord">Update this listing</a></p>
 </article>
 </div>
 
@@ -261,7 +261,7 @@ card lists different local settings.
 
 <div class="mc-community-card">
 <p><strong>Telegram:</strong> <a href="https://t.me/MeshCoreCAN" rel="noopener">Alberta topic in MeshCore Canada</a> <span class="mc-community-external">(external)</span></p>
-<p><strong>Contact check:</strong> Verified on 2026-08-29</p>
+<p><strong>Contact check:</strong> Links checked on 2026-08-29</p>
 </div>
 
 ## Add or update a listing

--- a/docs/provinces/british-columbia.fr.md
+++ b/docs/provinces/british-columbia.fr.md
@@ -43,7 +43,7 @@ sauf si une fiche indique des réglages locaux différents.
 <dl class="mc-community-facts">
 <div><dt>Réglages</dt>
 <dd>Préréglage radio : <code>Custom</code>; Valeurs radio brutes : <code>910.425 MHz / 62.5 kHz / SF7 / CR5</code></dd></div>
-<div><dt>Dernière vérification</dt>
+<div><dt>Fiche révisée</dt>
 <dd>2026-08-29</dd></div>
 </dl>
 <div class="mc-community-override" role="note">
@@ -57,7 +57,7 @@ sauf si une fiche indique des réglages locaux différents.
 <p class="mc-community-contact-health">
 <strong>Vérification :</strong> Effectuée le 2026-08-29
 </p>
-<p class="mc-community-card__action"><a href="../../submit-idea/">Mettre cette fiche à jour</a></p>
+<p class="mc-community-card__action"><a href="../../submit-idea/?community=bc-mesh&amp;source_page=https%3A%2F%2Fmeshcore.ca%2Ffr%2Fprovinces%2Fbritish-columbia%2F%23community-bc-mesh">Mettre cette fiche à jour</a></p>
 </article>
 <article class="mc-community-card mc-community-card--detail" id="community-salish-mesh">
 <div class="mc-community-card__header">
@@ -68,7 +68,7 @@ sauf si une fiche indique des réglages locaux différents.
 <dl class="mc-community-facts">
 <div><dt>Réglages</dt>
 <dd>Réglages par défaut du Canada</dd></div>
-<div><dt>Dernière vérification</dt>
+<div><dt>Fiche révisée</dt>
 <dd>2026-08-29</dd></div>
 </dl>
 <h4>Coordonnées</h4>
@@ -78,7 +78,7 @@ sauf si une fiche indique des réglages locaux différents.
 <p class="mc-community-contact-health">
 <strong>Vérification :</strong> Effectuée le 2026-08-29
 </p>
-<p class="mc-community-card__action"><a href="../../submit-idea/">Mettre cette fiche à jour</a></p>
+<p class="mc-community-card__action"><a href="../../submit-idea/?community=salish-mesh&amp;source_page=https%3A%2F%2Fmeshcore.ca%2Ffr%2Fprovinces%2Fbritish-columbia%2F%23community-salish-mesh">Mettre cette fiche à jour</a></p>
 </article>
 </div>
 

--- a/docs/provinces/british-columbia.md
+++ b/docs/provinces/british-columbia.md
@@ -42,7 +42,7 @@ card lists different local settings.
 <dl class="mc-community-facts">
 <div><dt>Settings</dt>
 <dd>Radio preset: <code>Custom</code>; Raw radio values: <code>910.425 MHz / 62.5 kHz / SF7 / CR5</code></dd></div>
-<div><dt>Last verified</dt>
+<div><dt>Listing reviewed</dt>
 <dd>2026-08-29</dd></div>
 </dl>
 <div class="mc-community-override" role="note">
@@ -54,9 +54,9 @@ card lists different local settings.
 <li><strong>Website:</strong> <a href="https://ridgeline.ve7kod.ca/about" rel="noopener">Ridgeline network map and tools</a> <span class="mc-community-external">(external)</span></li>
 </ul>
 <p class="mc-community-contact-health">
-<strong>Contact check:</strong> Verified on 2026-08-29
+<strong>Contact check:</strong> Links checked on 2026-08-29
 </p>
-<p class="mc-community-card__action"><a href="../../submit-idea/">Update this listing</a></p>
+<p class="mc-community-card__action"><a href="../../submit-idea/?community=bc-mesh&amp;source_page=https%3A%2F%2Fmeshcore.ca%2Fprovinces%2Fbritish-columbia%2F%23community-bc-mesh">Update this listing</a></p>
 </article>
 <article class="mc-community-card mc-community-card--detail" id="community-salish-mesh">
 <div class="mc-community-card__header">
@@ -67,7 +67,7 @@ card lists different local settings.
 <dl class="mc-community-facts">
 <div><dt>Settings</dt>
 <dd>Uses the Canada defaults</dd></div>
-<div><dt>Last verified</dt>
+<div><dt>Listing reviewed</dt>
 <dd>2026-08-29</dd></div>
 </dl>
 <h4>Contacts</h4>
@@ -75,9 +75,9 @@ card lists different local settings.
 <li><strong>Website:</strong> <a href="https://salishmesh.net/" rel="noopener">Salish Mesh website</a> <span class="mc-community-external">(external)</span></li>
 </ul>
 <p class="mc-community-contact-health">
-<strong>Contact check:</strong> Verified on 2026-08-29
+<strong>Contact check:</strong> Links checked on 2026-08-29
 </p>
-<p class="mc-community-card__action"><a href="../../submit-idea/">Update this listing</a></p>
+<p class="mc-community-card__action"><a href="../../submit-idea/?community=salish-mesh&amp;source_page=https%3A%2F%2Fmeshcore.ca%2Fprovinces%2Fbritish-columbia%2F%23community-salish-mesh">Update this listing</a></p>
 </article>
 </div>
 

--- a/docs/provinces/index.fr.md
+++ b/docs/provinces/index.fr.md
@@ -78,7 +78,7 @@ complète fonctionne sans carte, autorisation de localisation ni compte GitHub.
 <p class="mc-community-area">Lower Mainland et île de Vancouver</p>
 <p><strong>Province ou territoire :</strong> <a href="british-columbia/">Colombie-Britannique</a></p>
 <p><strong>Réglages :</strong> Réglages locaux différents — Préréglage radio : <code>Custom</code>; Valeurs radio brutes : <code>910.425 MHz / 62.5 kHz / SF7 / CR5</code></p>
-<p><strong>Dernière vérification :</strong> 2026-08-29</p>
+<p><strong>Fiche révisée :</strong> 2026-08-29</p>
 <ul class="mc-community-contacts">
 <li><strong>Site Web :</strong> <a href="https://ridgeline.ve7kod.ca/about" rel="noopener">Carte et outils du réseau Ridgeline</a> <span class="mc-community-external">(externe)</span></li>
 </ul>
@@ -92,7 +92,7 @@ complète fonctionne sans carte, autorisation de localisation ni compte GitHub.
 <p class="mc-community-area">Mer des Salish et environs</p>
 <p><strong>Province ou territoire :</strong> <a href="british-columbia/">Colombie-Britannique</a></p>
 <p><strong>Réglages :</strong> Réglages par défaut du Canada</p>
-<p><strong>Dernière vérification :</strong> 2026-08-29</p>
+<p><strong>Fiche révisée :</strong> 2026-08-29</p>
 <ul class="mc-community-contacts">
 <li><strong>Site Web :</strong> <a href="https://salishmesh.net/" rel="noopener">Site Web de Salish Mesh</a> <span class="mc-community-external">(externe)</span></li>
 </ul>
@@ -107,7 +107,7 @@ complète fonctionne sans carte, autorisation de localisation ni compte GitHub.
 <p class="mc-community-summary">Développement du réseau maillé LoRa hors réseau de l’Alberta, exploité par la communauté</p>
 <p><strong>Province ou territoire :</strong> <a href="alberta/">Alberta</a></p>
 <p><strong>Réglages :</strong> Réglages par défaut du Canada</p>
-<p><strong>Dernière vérification :</strong> 2026-08-29</p>
+<p><strong>Fiche révisée :</strong> 2026-08-29</p>
 <ul class="mc-community-contacts">
 <li><strong>Site Web :</strong> <a href="https://albertamesh.ca/" rel="noopener">AlbertaMesh.ca</a> <span class="mc-community-external">(externe)</span></li>
 <li><strong>Discord :</strong> <a href="https://discord.gg/CznDhsRWnJ" rel="noopener">Discord d’Alberta MeshCore</a> <span class="mc-community-external">(externe)</span></li>
@@ -129,7 +129,7 @@ complète fonctionne sans carte, autorisation de localisation ni compte GitHub.
 <p class="mc-community-summary">Utilise l’identifiant régional YYC partagé avec le réseau régional de Calgary</p>
 <p><strong>Province ou territoire :</strong> <a href="alberta/">Alberta</a></p>
 <p><strong>Réglages :</strong> Réglages par défaut du Canada</p>
-<p><strong>Dernière vérification :</strong> 2026-08-29</p>
+<p><strong>Fiche révisée :</strong> 2026-08-29</p>
 <ul class="mc-community-contacts">
 <li><strong>Site Web :</strong> <a href="https://albertamesh.ca/airdrie/" rel="noopener">Réseau MeshCore d’Airdrie</a> <span class="mc-community-external">(externe)</span></li>
 <li><strong>Site Web :</strong> <a href="https://albertamesh.ca/airdrie/configuration/" rel="noopener">Guide de configuration d’Airdrie</a> <span class="mc-community-external">(externe)</span></li>
@@ -147,7 +147,7 @@ complète fonctionne sans carte, autorisation de localisation ni compte GitHub.
 <p class="mc-community-area">Calgary et environs</p>
 <p><strong>Province ou territoire :</strong> <a href="alberta/">Alberta</a></p>
 <p><strong>Réglages :</strong> Réglages par défaut du Canada</p>
-<p><strong>Dernière vérification :</strong> 2026-08-29</p>
+<p><strong>Fiche révisée :</strong> 2026-08-29</p>
 <ul class="mc-community-contacts">
 <li><strong>Telegram :</strong> <a href="https://t.me/meshtAlta" rel="noopener">Sujet sur Calgary dans Mesh Alberta</a> <span class="mc-community-external">(externe)</span></li>
 <li><strong>Discord :</strong> Canal régional Canada — Calgary, Alberta et environs sur le Discord de MeshCore</li>
@@ -163,7 +163,7 @@ complète fonctionne sans carte, autorisation de localisation ni compte GitHub.
 <p class="mc-community-summary">Première région lancée sur AlbertaMesh.ca</p>
 <p><strong>Province ou territoire :</strong> <a href="alberta/">Alberta</a></p>
 <p><strong>Réglages :</strong> Réglages par défaut du Canada</p>
-<p><strong>Dernière vérification :</strong> 2026-08-29</p>
+<p><strong>Fiche révisée :</strong> 2026-08-29</p>
 <ul class="mc-community-contacts">
 <li><strong>Site Web :</strong> <a href="https://albertamesh.ca/calgary/" rel="noopener">Guide de la communauté de Calgary</a> <span class="mc-community-external">(externe)</span></li>
 <li><strong>Discord :</strong> <a href="https://discord.gg/CznDhsRWnJ" rel="noopener">Discord d’Alberta MeshCore</a> <span class="mc-community-external">(externe)</span></li>
@@ -182,7 +182,7 @@ complète fonctionne sans carte, autorisation de localisation ni compte GitHub.
 <p class="mc-community-summary">Communauté régionale d’Edmonton au sein d’Alberta MeshCore</p>
 <p><strong>Province ou territoire :</strong> <a href="alberta/">Alberta</a></p>
 <p><strong>Réglages :</strong> Réglages par défaut du Canada</p>
-<p><strong>Dernière vérification :</strong> 2026-08-29</p>
+<p><strong>Fiche révisée :</strong> 2026-08-29</p>
 <ul class="mc-community-contacts">
 <li><strong>Site Web :</strong> <a href="https://albertamesh.ca/edmonton/" rel="noopener">Edmonton sur AlbertaMesh.ca</a> <span class="mc-community-external">(externe)</span></li>
 <li><strong>Site Web :</strong> <a href="https://albertamesh.ca/edmonton/configuration/" rel="noopener">Guide de configuration d’Edmonton</a> <span class="mc-community-external">(externe)</span></li>
@@ -200,7 +200,7 @@ complète fonctionne sans carte, autorisation de localisation ni compte GitHub.
 <p class="mc-community-summary">Communauté du réseau maillé d’Edmonton axée sur MeshCore</p>
 <p><strong>Province ou territoire :</strong> <a href="alberta/">Alberta</a></p>
 <p><strong>Réglages :</strong> Réglages par défaut du Canada</p>
-<p><strong>Dernière vérification :</strong> 2026-08-29</p>
+<p><strong>Fiche révisée :</strong> 2026-08-29</p>
 <ul class="mc-community-contacts">
 <li><strong>Site Web :</strong> <a href="https://yegmesh.ca/p/getting-started" rel="noopener">Bien démarrer</a> <span class="mc-community-external">(externe)</span></li>
 <li><strong>Site Web :</strong> <a href="https://yegmesh.ca/p/meshcore-defaults" rel="noopener">Réglages par défaut de MeshCore</a> <span class="mc-community-external">(externe)</span></li>
@@ -218,7 +218,7 @@ complète fonctionne sans carte, autorisation de localisation ni compte GitHub.
 <p class="mc-community-summary">Relier Lethbridge, un nœud à la fois</p>
 <p><strong>Province ou territoire :</strong> <a href="alberta/">Alberta</a></p>
 <p><strong>Réglages :</strong> Réglages par défaut du Canada</p>
-<p><strong>Dernière vérification :</strong> 2026-08-29</p>
+<p><strong>Fiche révisée :</strong> 2026-08-29</p>
 <ul class="mc-community-contacts">
 <li><strong>Site Web :</strong> <a href="https://www.yqlmesh.com/" rel="noopener">Site Web de YQLMesh</a> <span class="mc-community-external">(externe)</span></li>
 <li><strong>Site Web :</strong> <a href="https://albertamesh.ca/lethbridge/" rel="noopener">Page régionale de Lethbridge</a> <span class="mc-community-external">(externe)</span></li>
@@ -239,7 +239,7 @@ complète fonctionne sans carte, autorisation de localisation ni compte GitHub.
 <p class="mc-community-area">Sud de l’Alberta, y compris Cardston, Magrath, Raymond et les environs</p>
 <p><strong>Province ou territoire :</strong> <a href="alberta/">Alberta</a></p>
 <p><strong>Réglages :</strong> Réglages par défaut du Canada</p>
-<p><strong>Dernière vérification :</strong> 2026-08-29</p>
+<p><strong>Fiche révisée :</strong> 2026-08-29</p>
 <ul class="mc-community-contacts">
 <li><strong>Discord :</strong> Canal régional Canada — Sud de l’Alberta sur le Discord de MeshCore</li>
 <li><strong>Telegram :</strong> <a href="https://t.me/meshtAlta" rel="noopener">Sujet sur Cardston dans Mesh Alberta</a> <span class="mc-community-external">(externe)</span></li>
@@ -254,7 +254,7 @@ complète fonctionne sans carte, autorisation de localisation ni compte GitHub.
 <p class="mc-community-area">Calgary</p>
 <p><strong>Province ou territoire :</strong> <a href="alberta/">Alberta</a></p>
 <p><strong>Réglages :</strong> Réglages par défaut du Canada</p>
-<p><strong>Dernière vérification :</strong> 2026-08-29</p>
+<p><strong>Fiche révisée :</strong> 2026-08-29</p>
 <ul class="mc-community-contacts">
 <li><strong>Discord :</strong> <a href="https://discord.gg/CznDhsRWnJ" rel="noopener">Discord de YYC MeshCore</a> <span class="mc-community-external">(externe)</span></li>
 <li><strong>Site Web :</strong> <a href="https://meshmonitoring.com/" rel="noopener">MeshMonitoring</a> <span class="mc-community-external">(externe)</span></li>
@@ -269,7 +269,7 @@ complète fonctionne sans carte, autorisation de localisation ni compte GitHub.
 <p class="mc-community-area">Centre de la Saskatchewan</p>
 <p><strong>Province ou territoire :</strong> <a href="saskatchewan/">Saskatchewan</a></p>
 <p><strong>Réglages :</strong> Réglages par défaut du Canada</p>
-<p><strong>Dernière vérification :</strong> 2026-08-29</p>
+<p><strong>Fiche révisée :</strong> 2026-08-29</p>
 <ul class="mc-community-contacts">
 <li><strong>Telegram :</strong> <a href="https://t.me/MeshtSaska" rel="noopener">Mesh Saskatchewan Telegram</a> <span class="mc-community-external">(externe)</span></li>
 </ul>
@@ -283,7 +283,7 @@ complète fonctionne sans carte, autorisation de localisation ni compte GitHub.
 <p class="mc-community-area">Regina et sud de la Saskatchewan</p>
 <p><strong>Province ou territoire :</strong> <a href="saskatchewan/">Saskatchewan</a></p>
 <p><strong>Réglages :</strong> Réglages par défaut du Canada</p>
-<p><strong>Dernière vérification :</strong> 2026-08-29</p>
+<p><strong>Fiche révisée :</strong> 2026-08-29</p>
 <ul class="mc-community-contacts">
 </ul>
 <p class="mc-community-card__action"><a href="saskatchewan/#community-yqrmesh">Voir les détails de la fiche</a></p>
@@ -296,7 +296,7 @@ complète fonctionne sans carte, autorisation de localisation ni compte GitHub.
 <p class="mc-community-area">Est de l’Ontario et ouest du Québec</p>
 <p><strong>Province ou territoire :</strong> <a href="ontario/">Ontario</a></p>
 <p><strong>Réglages :</strong> Réglages par défaut du Canada</p>
-<p><strong>Dernière vérification :</strong> 2026-08-29</p>
+<p><strong>Fiche révisée :</strong> 2026-08-29</p>
 <ul class="mc-community-contacts">
 <li><strong>Discord :</strong> <a href="https://discord.gg/WSyNd8SfNr" rel="noopener">Discord de Greater Ottawa Mesh Enthusiasts</a> <span class="mc-community-external">(externe)</span></li>
 <li><strong>Site Web :</strong> <a href="https://ottawamesh.ca/" rel="noopener">Site Web d’Ottawa Mesh</a> <span class="mc-community-external">(externe)</span></li>
@@ -311,7 +311,7 @@ complète fonctionne sans carte, autorisation de localisation ni compte GitHub.
 <p class="mc-community-area">Sud de l’Ontario</p>
 <p><strong>Province ou territoire :</strong> <a href="ontario/">Ontario</a></p>
 <p><strong>Réglages :</strong> Réglages par défaut du Canada</p>
-<p><strong>Dernière vérification :</strong> 2026-08-29</p>
+<p><strong>Fiche révisée :</strong> 2026-08-29</p>
 <ul class="mc-community-contacts">
 <li><strong>Discord :</strong> <a href="https://discord.gg/wSHbeb86r4" rel="noopener">Discord de GTA+-Lora-Meshes</a> <span class="mc-community-external">(externe)</span></li>
 </ul>
@@ -325,7 +325,7 @@ complète fonctionne sans carte, autorisation de localisation ni compte GitHub.
 <p class="mc-community-area">Région de Quinte, y compris Belleville, Trenton, le comté de Prince Edward et les environs</p>
 <p><strong>Province ou territoire :</strong> <a href="ontario/">Ontario</a></p>
 <p><strong>Réglages :</strong> Réglages par défaut du Canada</p>
-<p><strong>Dernière vérification :</strong> 2026-08-29</p>
+<p><strong>Fiche révisée :</strong> 2026-08-29</p>
 <ul class="mc-community-contacts">
 <li><strong>Discord :</strong> <a href="https://discord.gg/V5esJEP67X" rel="noopener">Discord de Quinte Mesh Network</a> <span class="mc-community-external">(externe)</span></li>
 <li><strong>Site Web :</strong> <a href="https://quintemesh.ca/" rel="noopener">Site Web de Quinte Mesh Network</a> <span class="mc-community-external">(externe)</span></li>
@@ -340,7 +340,7 @@ complète fonctionne sans carte, autorisation de localisation ni compte GitHub.
 <p class="mc-community-area">Charlevoix, y compris La Malbaie</p>
 <p><strong>Province ou territoire :</strong> <a href="quebec/">Québec</a></p>
 <p><strong>Réglages :</strong> Réglages par défaut du Canada</p>
-<p><strong>Dernière vérification :</strong> 2026-08-29</p>
+<p><strong>Fiche révisée :</strong> 2026-08-29</p>
 <ul class="mc-community-contacts">
 <li><strong>Site Web :</strong> <a href="https://chxmesh.ca/" rel="noopener">Réseau MESH de Charlevoix</a> <span class="mc-community-external">(externe)</span></li>
 </ul>
@@ -354,7 +354,7 @@ complète fonctionne sans carte, autorisation de localisation ni compte GitHub.
 <p class="mc-community-area">Québec</p>
 <p><strong>Province ou territoire :</strong> <a href="quebec/">Québec</a></p>
 <p><strong>Réglages :</strong> Réglages par défaut du Canada</p>
-<p><strong>Dernière vérification :</strong> 2026-08-29</p>
+<p><strong>Fiche révisée :</strong> 2026-08-29</p>
 <ul class="mc-community-contacts">
 <li><strong>Telegram :</strong> <a href="https://t.me/meshtQuebec" rel="noopener">Mesh Quebec Telegram</a> <span class="mc-community-external">(externe)</span></li>
 </ul>
@@ -368,7 +368,7 @@ complète fonctionne sans carte, autorisation de localisation ni compte GitHub.
 <p class="mc-community-area">Grand Montréal</p>
 <p><strong>Province ou territoire :</strong> <a href="quebec/">Québec</a></p>
 <p><strong>Réglages :</strong> Réglages par défaut du Canada</p>
-<p><strong>Dernière vérification :</strong> 2026-08-29</p>
+<p><strong>Fiche révisée :</strong> 2026-08-29</p>
 <ul class="mc-community-contacts">
 <li><strong>Site Web :</strong> <a href="https://www.montrealmesh.ca" rel="noopener">Site Web de Montreal Mesh</a> <span class="mc-community-external">(externe)</span></li>
 </ul>
@@ -382,7 +382,7 @@ complète fonctionne sans carte, autorisation de localisation ni compte GitHub.
 <p class="mc-community-area">Ville de Québec</p>
 <p><strong>Province ou territoire :</strong> <a href="quebec/">Québec</a></p>
 <p><strong>Réglages :</strong> Réglages par défaut du Canada</p>
-<p><strong>Dernière vérification :</strong> 2026-08-29</p>
+<p><strong>Fiche révisée :</strong> 2026-08-29</p>
 <ul class="mc-community-contacts">
 <li><strong>Discord :</strong> <a href="https://discord.gg/UhGjTF2MfA" rel="noopener">Discord du Réseau Mesh de la Capitale YQB</a> <span class="mc-community-external">(externe)</span></li>
 </ul>
@@ -396,7 +396,7 @@ complète fonctionne sans carte, autorisation de localisation ni compte GitHub.
 <p class="mc-community-area">Saguenay–Lac-Saint-Jean (YTF)</p>
 <p><strong>Province ou territoire :</strong> <a href="quebec/">Québec</a></p>
 <p><strong>Réglages :</strong> Réglages par défaut du Canada</p>
-<p><strong>Dernière vérification :</strong> 2026-08-29</p>
+<p><strong>Fiche révisée :</strong> 2026-08-29</p>
 <ul class="mc-community-contacts">
 <li><strong>Facebook :</strong> <a href="https://www.facebook.com/share/g/1GjkHAyZAM/" rel="noopener">Facebook du Réseau Mesh du Saguenay–Lac-Saint-Jean YTF</a> <span class="mc-community-external">(externe)</span></li>
 <li><strong>MeshMapper :</strong> <a href="https://ytf.meshmapper.net/" rel="noopener">Carte MeshMapper du Réseau Mesh du Saguenay–Lac-Saint-Jean YTF</a> <span class="mc-community-external">(externe)</span></li>
@@ -411,7 +411,7 @@ complète fonctionne sans carte, autorisation de localisation ni compte GitHub.
 <p class="mc-community-area">Montréal</p>
 <p><strong>Province ou territoire :</strong> <a href="quebec/">Québec</a></p>
 <p><strong>Réglages :</strong> Réglages par défaut du Canada</p>
-<p><strong>Dernière vérification :</strong> 2026-08-29</p>
+<p><strong>Fiche révisée :</strong> 2026-08-29</p>
 <ul class="mc-community-contacts">
 <li><strong>Site Web :</strong> <a href="https://lora.reseaulibre.ca/" rel="noopener">Site Web de Réseau Libre</a> <span class="mc-community-external">(externe)</span></li>
 </ul>
@@ -425,7 +425,7 @@ complète fonctionne sans carte, autorisation de localisation ni compte GitHub.
 <p class="mc-community-area">Sud du Nouveau-Brunswick, y compris Fredericton, Saint John, Moncton et les environs</p>
 <p><strong>Province ou territoire :</strong> <a href="new-brunswick/">Nouveau-Brunswick</a></p>
 <p><strong>Réglages :</strong> Réglages par défaut du Canada</p>
-<p><strong>Dernière vérification :</strong> 2026-08-29</p>
+<p><strong>Fiche révisée :</strong> 2026-08-29</p>
 <ul class="mc-community-contacts">
 <li><strong>Facebook :</strong> <a href="https://www.facebook.com/groups/613466831163684" rel="noopener">MESHCORE Saint John, N.B.</a> <span class="mc-community-external">(externe)</span></li>
 </ul>
@@ -439,7 +439,7 @@ complète fonctionne sans carte, autorisation de localisation ni compte GitHub.
 <p class="mc-community-area">Comté de Lunenburg</p>
 <p><strong>Province ou territoire :</strong> <a href="nova-scotia/">Nouvelle-Écosse</a></p>
 <p><strong>Réglages :</strong> Réglages par défaut du Canada</p>
-<p><strong>Dernière vérification :</strong> 2026-08-29</p>
+<p><strong>Fiche révisée :</strong> 2026-08-29</p>
 <ul class="mc-community-contacts">
 <li><strong>Site Web :</strong> <a href="http://www.lunenburgcountymesh.ca" rel="noopener">Site Web de Lunenburg County Mesh</a> <span class="mc-community-external">(externe)</span></li>
 </ul>

--- a/docs/provinces/index.md
+++ b/docs/provinces/index.md
@@ -78,7 +78,7 @@ works without a map, location permission, or a GitHub account.
 <p class="mc-community-area">Lower Mainland and Vancouver Island</p>
 <p><strong>Province:</strong> <a href="british-columbia/">British Columbia</a></p>
 <p><strong>Settings:</strong> Different local settings — Radio preset: <code>Custom</code>; Raw radio values: <code>910.425 MHz / 62.5 kHz / SF7 / CR5</code></p>
-<p><strong>Last verified:</strong> 2026-08-29</p>
+<p><strong>Listing reviewed:</strong> 2026-08-29</p>
 <ul class="mc-community-contacts">
 <li><strong>Website:</strong> <a href="https://ridgeline.ve7kod.ca/about" rel="noopener">Ridgeline network map and tools</a> <span class="mc-community-external">(external)</span></li>
 </ul>
@@ -92,7 +92,7 @@ works without a map, location permission, or a GitHub account.
 <p class="mc-community-area">Salish Sea and surrounding area</p>
 <p><strong>Province:</strong> <a href="british-columbia/">British Columbia</a></p>
 <p><strong>Settings:</strong> Uses the Canada defaults</p>
-<p><strong>Last verified:</strong> 2026-08-29</p>
+<p><strong>Listing reviewed:</strong> 2026-08-29</p>
 <ul class="mc-community-contacts">
 <li><strong>Website:</strong> <a href="https://salishmesh.net/" rel="noopener">Salish Mesh website</a> <span class="mc-community-external">(external)</span></li>
 </ul>
@@ -107,7 +107,7 @@ works without a map, location permission, or a GitHub account.
 <p class="mc-community-summary">Building Alberta&#x27;s community-operated off-grid LoRa mesh network</p>
 <p><strong>Province:</strong> <a href="alberta/">Alberta</a></p>
 <p><strong>Settings:</strong> Uses the Canada defaults</p>
-<p><strong>Last verified:</strong> 2026-08-29</p>
+<p><strong>Listing reviewed:</strong> 2026-08-29</p>
 <ul class="mc-community-contacts">
 <li><strong>Website:</strong> <a href="https://albertamesh.ca/" rel="noopener">AlbertaMesh.ca</a> <span class="mc-community-external">(external)</span></li>
 <li><strong>Discord:</strong> <a href="https://discord.gg/CznDhsRWnJ" rel="noopener">Alberta MeshCore Discord</a> <span class="mc-community-external">(external)</span></li>
@@ -129,7 +129,7 @@ works without a map, location permission, or a GitHub account.
 <p class="mc-community-summary">Uses the YYC regional identifier shared with the Calgary regional network</p>
 <p><strong>Province:</strong> <a href="alberta/">Alberta</a></p>
 <p><strong>Settings:</strong> Uses the Canada defaults</p>
-<p><strong>Last verified:</strong> 2026-08-29</p>
+<p><strong>Listing reviewed:</strong> 2026-08-29</p>
 <ul class="mc-community-contacts">
 <li><strong>Website:</strong> <a href="https://albertamesh.ca/airdrie/" rel="noopener">Airdrie MeshCore Network</a> <span class="mc-community-external">(external)</span></li>
 <li><strong>Website:</strong> <a href="https://albertamesh.ca/airdrie/configuration/" rel="noopener">Airdrie configuration guide</a> <span class="mc-community-external">(external)</span></li>
@@ -147,7 +147,7 @@ works without a map, location permission, or a GitHub account.
 <p class="mc-community-area">Calgary and area</p>
 <p><strong>Province:</strong> <a href="alberta/">Alberta</a></p>
 <p><strong>Settings:</strong> Uses the Canada defaults</p>
-<p><strong>Last verified:</strong> 2026-08-29</p>
+<p><strong>Listing reviewed:</strong> 2026-08-29</p>
 <ul class="mc-community-contacts">
 <li><strong>Telegram:</strong> <a href="https://t.me/meshtAlta" rel="noopener">Calgary topic in Mesh Alberta</a> <span class="mc-community-external">(external)</span></li>
 <li><strong>Discord:</strong> Canada - Calgary, Alberta &amp; Area regional channel in the MeshCore Discord</li>
@@ -163,7 +163,7 @@ works without a map, location permission, or a GitHub account.
 <p class="mc-community-summary">Initial AlbertaMesh.ca launch region</p>
 <p><strong>Province:</strong> <a href="alberta/">Alberta</a></p>
 <p><strong>Settings:</strong> Uses the Canada defaults</p>
-<p><strong>Last verified:</strong> 2026-08-29</p>
+<p><strong>Listing reviewed:</strong> 2026-08-29</p>
 <ul class="mc-community-contacts">
 <li><strong>Website:</strong> <a href="https://albertamesh.ca/calgary/" rel="noopener">Calgary community guide</a> <span class="mc-community-external">(external)</span></li>
 <li><strong>Discord:</strong> <a href="https://discord.gg/CznDhsRWnJ" rel="noopener">Alberta MeshCore Discord</a> <span class="mc-community-external">(external)</span></li>
@@ -182,7 +182,7 @@ works without a map, location permission, or a GitHub account.
 <p class="mc-community-summary">Edmonton regional community within Alberta MeshCore</p>
 <p><strong>Province:</strong> <a href="alberta/">Alberta</a></p>
 <p><strong>Settings:</strong> Uses the Canada defaults</p>
-<p><strong>Last verified:</strong> 2026-08-29</p>
+<p><strong>Listing reviewed:</strong> 2026-08-29</p>
 <ul class="mc-community-contacts">
 <li><strong>Website:</strong> <a href="https://albertamesh.ca/edmonton/" rel="noopener">Edmonton on AlbertaMesh.ca</a> <span class="mc-community-external">(external)</span></li>
 <li><strong>Website:</strong> <a href="https://albertamesh.ca/edmonton/configuration/" rel="noopener">Edmonton configuration guide</a> <span class="mc-community-external">(external)</span></li>
@@ -200,7 +200,7 @@ works without a map, location permission, or a GitHub account.
 <p class="mc-community-summary">Edmonton mesh network community focused on MeshCore</p>
 <p><strong>Province:</strong> <a href="alberta/">Alberta</a></p>
 <p><strong>Settings:</strong> Uses the Canada defaults</p>
-<p><strong>Last verified:</strong> 2026-08-29</p>
+<p><strong>Listing reviewed:</strong> 2026-08-29</p>
 <ul class="mc-community-contacts">
 <li><strong>Website:</strong> <a href="https://yegmesh.ca/p/getting-started" rel="noopener">Getting started</a> <span class="mc-community-external">(external)</span></li>
 <li><strong>Website:</strong> <a href="https://yegmesh.ca/p/meshcore-defaults" rel="noopener">MeshCore defaults</a> <span class="mc-community-external">(external)</span></li>
@@ -218,7 +218,7 @@ works without a map, location permission, or a GitHub account.
 <p class="mc-community-summary">Connecting Lethbridge, one node at a time</p>
 <p><strong>Province:</strong> <a href="alberta/">Alberta</a></p>
 <p><strong>Settings:</strong> Uses the Canada defaults</p>
-<p><strong>Last verified:</strong> 2026-08-29</p>
+<p><strong>Listing reviewed:</strong> 2026-08-29</p>
 <ul class="mc-community-contacts">
 <li><strong>Website:</strong> <a href="https://www.yqlmesh.com/" rel="noopener">YQLMesh website</a> <span class="mc-community-external">(external)</span></li>
 <li><strong>Website:</strong> <a href="https://albertamesh.ca/lethbridge/" rel="noopener">Lethbridge regional page</a> <span class="mc-community-external">(external)</span></li>
@@ -239,7 +239,7 @@ works without a map, location permission, or a GitHub account.
 <p class="mc-community-area">Southern Alberta, including Cardston, Magrath, Raymond, and nearby areas</p>
 <p><strong>Province:</strong> <a href="alberta/">Alberta</a></p>
 <p><strong>Settings:</strong> Uses the Canada defaults</p>
-<p><strong>Last verified:</strong> 2026-08-29</p>
+<p><strong>Listing reviewed:</strong> 2026-08-29</p>
 <ul class="mc-community-contacts">
 <li><strong>Discord:</strong> Canada - Southern Alberta regional channel in the MeshCore Discord</li>
 <li><strong>Telegram:</strong> <a href="https://t.me/meshtAlta" rel="noopener">Cardston topic in Mesh Alberta</a> <span class="mc-community-external">(external)</span></li>
@@ -254,7 +254,7 @@ works without a map, location permission, or a GitHub account.
 <p class="mc-community-area">Calgary</p>
 <p><strong>Province:</strong> <a href="alberta/">Alberta</a></p>
 <p><strong>Settings:</strong> Uses the Canada defaults</p>
-<p><strong>Last verified:</strong> 2026-08-29</p>
+<p><strong>Listing reviewed:</strong> 2026-08-29</p>
 <ul class="mc-community-contacts">
 <li><strong>Discord:</strong> <a href="https://discord.gg/CznDhsRWnJ" rel="noopener">YYC MeshCore Discord</a> <span class="mc-community-external">(external)</span></li>
 <li><strong>Website:</strong> <a href="https://meshmonitoring.com/" rel="noopener">MeshMonitoring</a> <span class="mc-community-external">(external)</span></li>
@@ -269,7 +269,7 @@ works without a map, location permission, or a GitHub account.
 <p class="mc-community-area">Central Saskatchewan</p>
 <p><strong>Province:</strong> <a href="saskatchewan/">Saskatchewan</a></p>
 <p><strong>Settings:</strong> Uses the Canada defaults</p>
-<p><strong>Last verified:</strong> 2026-08-29</p>
+<p><strong>Listing reviewed:</strong> 2026-08-29</p>
 <ul class="mc-community-contacts">
 <li><strong>Telegram:</strong> <a href="https://t.me/MeshtSaska" rel="noopener">Mesh Saskatchewan Telegram</a> <span class="mc-community-external">(external)</span></li>
 </ul>
@@ -283,7 +283,7 @@ works without a map, location permission, or a GitHub account.
 <p class="mc-community-area">Regina and Southern Saskatchewan</p>
 <p><strong>Province:</strong> <a href="saskatchewan/">Saskatchewan</a></p>
 <p><strong>Settings:</strong> Uses the Canada defaults</p>
-<p><strong>Last verified:</strong> 2026-08-29</p>
+<p><strong>Listing reviewed:</strong> 2026-08-29</p>
 <ul class="mc-community-contacts">
 </ul>
 <p class="mc-community-card__action"><a href="saskatchewan/#community-yqrmesh">View listing details</a></p>
@@ -296,7 +296,7 @@ works without a map, location permission, or a GitHub account.
 <p class="mc-community-area">Eastern Ontario and Western Quebec</p>
 <p><strong>Province:</strong> <a href="ontario/">Ontario</a></p>
 <p><strong>Settings:</strong> Uses the Canada defaults</p>
-<p><strong>Last verified:</strong> 2026-08-29</p>
+<p><strong>Listing reviewed:</strong> 2026-08-29</p>
 <ul class="mc-community-contacts">
 <li><strong>Discord:</strong> <a href="https://discord.gg/WSyNd8SfNr" rel="noopener">Greater Ottawa Mesh Enthusiasts Discord</a> <span class="mc-community-external">(external)</span></li>
 <li><strong>Website:</strong> <a href="https://ottawamesh.ca/" rel="noopener">Ottawa Mesh website</a> <span class="mc-community-external">(external)</span></li>
@@ -311,7 +311,7 @@ works without a map, location permission, or a GitHub account.
 <p class="mc-community-area">Southern Ontario</p>
 <p><strong>Province:</strong> <a href="ontario/">Ontario</a></p>
 <p><strong>Settings:</strong> Uses the Canada defaults</p>
-<p><strong>Last verified:</strong> 2026-08-29</p>
+<p><strong>Listing reviewed:</strong> 2026-08-29</p>
 <ul class="mc-community-contacts">
 <li><strong>Discord:</strong> <a href="https://discord.gg/wSHbeb86r4" rel="noopener">GTA+-Lora-Meshes Discord</a> <span class="mc-community-external">(external)</span></li>
 </ul>
@@ -325,7 +325,7 @@ works without a map, location permission, or a GitHub account.
 <p class="mc-community-area">Quinte Region, including Belleville, Trenton, Prince Edward County, and nearby areas</p>
 <p><strong>Province:</strong> <a href="ontario/">Ontario</a></p>
 <p><strong>Settings:</strong> Uses the Canada defaults</p>
-<p><strong>Last verified:</strong> 2026-08-29</p>
+<p><strong>Listing reviewed:</strong> 2026-08-29</p>
 <ul class="mc-community-contacts">
 <li><strong>Discord:</strong> <a href="https://discord.gg/V5esJEP67X" rel="noopener">Quinte Mesh Network Discord</a> <span class="mc-community-external">(external)</span></li>
 <li><strong>Website:</strong> <a href="https://quintemesh.ca/" rel="noopener">Quinte Mesh Network website</a> <span class="mc-community-external">(external)</span></li>
@@ -340,7 +340,7 @@ works without a map, location permission, or a GitHub account.
 <p class="mc-community-area">Charlevoix, including La Malbaie</p>
 <p><strong>Province:</strong> <a href="quebec/">Quebec</a></p>
 <p><strong>Settings:</strong> Uses the Canada defaults</p>
-<p><strong>Last verified:</strong> 2026-08-29</p>
+<p><strong>Listing reviewed:</strong> 2026-08-29</p>
 <ul class="mc-community-contacts">
 <li><strong>Website:</strong> <a href="https://chxmesh.ca/" rel="noopener">Réseau MESH de Charlevoix</a> <span class="mc-community-external">(external)</span></li>
 </ul>
@@ -354,7 +354,7 @@ works without a map, location permission, or a GitHub account.
 <p class="mc-community-area">Quebec</p>
 <p><strong>Province:</strong> <a href="quebec/">Quebec</a></p>
 <p><strong>Settings:</strong> Uses the Canada defaults</p>
-<p><strong>Last verified:</strong> 2026-08-29</p>
+<p><strong>Listing reviewed:</strong> 2026-08-29</p>
 <ul class="mc-community-contacts">
 <li><strong>Telegram:</strong> <a href="https://t.me/meshtQuebec" rel="noopener">Mesh Quebec Telegram</a> <span class="mc-community-external">(external)</span></li>
 </ul>
@@ -368,7 +368,7 @@ works without a map, location permission, or a GitHub account.
 <p class="mc-community-area">Greater Montreal</p>
 <p><strong>Province:</strong> <a href="quebec/">Quebec</a></p>
 <p><strong>Settings:</strong> Uses the Canada defaults</p>
-<p><strong>Last verified:</strong> 2026-08-29</p>
+<p><strong>Listing reviewed:</strong> 2026-08-29</p>
 <ul class="mc-community-contacts">
 <li><strong>Website:</strong> <a href="https://www.montrealmesh.ca" rel="noopener">Montreal Mesh website</a> <span class="mc-community-external">(external)</span></li>
 </ul>
@@ -382,7 +382,7 @@ works without a map, location permission, or a GitHub account.
 <p class="mc-community-area">Quebec City</p>
 <p><strong>Province:</strong> <a href="quebec/">Quebec</a></p>
 <p><strong>Settings:</strong> Uses the Canada defaults</p>
-<p><strong>Last verified:</strong> 2026-08-29</p>
+<p><strong>Listing reviewed:</strong> 2026-08-29</p>
 <ul class="mc-community-contacts">
 <li><strong>Discord:</strong> <a href="https://discord.gg/UhGjTF2MfA" rel="noopener">Réseau Mesh de la Capitale YQB Discord</a> <span class="mc-community-external">(external)</span></li>
 </ul>
@@ -396,7 +396,7 @@ works without a map, location permission, or a GitHub account.
 <p class="mc-community-area">Saguenay–Lac-Saint-Jean (YTF)</p>
 <p><strong>Province:</strong> <a href="quebec/">Quebec</a></p>
 <p><strong>Settings:</strong> Uses the Canada defaults</p>
-<p><strong>Last verified:</strong> 2026-08-29</p>
+<p><strong>Listing reviewed:</strong> 2026-08-29</p>
 <ul class="mc-community-contacts">
 <li><strong>Facebook:</strong> <a href="https://www.facebook.com/share/g/1GjkHAyZAM/" rel="noopener">Réseau Mesh du Saguenay Lac st-Jean YTF Facebook</a> <span class="mc-community-external">(external)</span></li>
 <li><strong>MeshMapper:</strong> <a href="https://ytf.meshmapper.net/" rel="noopener">Réseau Mesh du Saguenay Lac st-Jean YTF MeshMapper</a> <span class="mc-community-external">(external)</span></li>
@@ -411,7 +411,7 @@ works without a map, location permission, or a GitHub account.
 <p class="mc-community-area">Montreal</p>
 <p><strong>Province:</strong> <a href="quebec/">Quebec</a></p>
 <p><strong>Settings:</strong> Uses the Canada defaults</p>
-<p><strong>Last verified:</strong> 2026-08-29</p>
+<p><strong>Listing reviewed:</strong> 2026-08-29</p>
 <ul class="mc-community-contacts">
 <li><strong>Website:</strong> <a href="https://lora.reseaulibre.ca/" rel="noopener">Réseau Libre website</a> <span class="mc-community-external">(external)</span></li>
 </ul>
@@ -425,7 +425,7 @@ works without a map, location permission, or a GitHub account.
 <p class="mc-community-area">Fredericton, Saint John, Moncton, and nearby areas</p>
 <p><strong>Province:</strong> <a href="new-brunswick/">New Brunswick</a></p>
 <p><strong>Settings:</strong> Uses the Canada defaults</p>
-<p><strong>Last verified:</strong> 2026-08-29</p>
+<p><strong>Listing reviewed:</strong> 2026-08-29</p>
 <ul class="mc-community-contacts">
 <li><strong>Facebook:</strong> <a href="https://www.facebook.com/groups/613466831163684" rel="noopener">MESHCORE Saint John, N.B.</a> <span class="mc-community-external">(external)</span></li>
 </ul>
@@ -439,7 +439,7 @@ works without a map, location permission, or a GitHub account.
 <p class="mc-community-area">Lunenburg County</p>
 <p><strong>Province:</strong> <a href="nova-scotia/">Nova Scotia</a></p>
 <p><strong>Settings:</strong> Uses the Canada defaults</p>
-<p><strong>Last verified:</strong> 2026-08-29</p>
+<p><strong>Listing reviewed:</strong> 2026-08-29</p>
 <ul class="mc-community-contacts">
 <li><strong>Website:</strong> <a href="http://www.lunenburgcountymesh.ca" rel="noopener">Lunenburg County Mesh website</a> <span class="mc-community-external">(external)</span></li>
 </ul>

--- a/docs/provinces/new-brunswick.fr.md
+++ b/docs/provinces/new-brunswick.fr.md
@@ -38,7 +38,7 @@ sauf si une fiche indique des réglages locaux différents.
 <dl class="mc-community-facts">
 <div><dt>Réglages</dt>
 <dd>Réglages par défaut du Canada</dd></div>
-<div><dt>Dernière vérification</dt>
+<div><dt>Fiche révisée</dt>
 <dd>2026-08-29</dd></div>
 </dl>
 <p class="mc-community-forming">
@@ -51,7 +51,7 @@ Ce groupe est en formation. Communiquez avec lui pour savoir ce qui fonctionne e
 <p class="mc-community-contact-health">
 <strong>Vérification :</strong> Pas encore effectuée
 </p>
-<p class="mc-community-card__action"><a href="../../submit-idea/">Mettre cette fiche à jour</a></p>
+<p class="mc-community-card__action"><a href="../../submit-idea/?community=southern-new-brunswick&amp;source_page=https%3A%2F%2Fmeshcore.ca%2Ffr%2Fprovinces%2Fnew-brunswick%2F%23community-southern-new-brunswick">Mettre cette fiche à jour</a></p>
 </article>
 </div>
 

--- a/docs/provinces/new-brunswick.md
+++ b/docs/provinces/new-brunswick.md
@@ -38,7 +38,7 @@ card lists different local settings.
 <dl class="mc-community-facts">
 <div><dt>Settings</dt>
 <dd>Uses the Canada defaults</dd></div>
-<div><dt>Last verified</dt>
+<div><dt>Listing reviewed</dt>
 <dd>2026-08-29</dd></div>
 </dl>
 <p class="mc-community-forming">
@@ -51,7 +51,7 @@ This group is forming. Contact it to learn what is working and where help is nee
 <p class="mc-community-contact-health">
 <strong>Contact check:</strong> Not yet verified
 </p>
-<p class="mc-community-card__action"><a href="../../submit-idea/">Update this listing</a></p>
+<p class="mc-community-card__action"><a href="../../submit-idea/?community=southern-new-brunswick&amp;source_page=https%3A%2F%2Fmeshcore.ca%2Fprovinces%2Fnew-brunswick%2F%23community-southern-new-brunswick">Update this listing</a></p>
 </article>
 </div>
 

--- a/docs/provinces/nova-scotia.fr.md
+++ b/docs/provinces/nova-scotia.fr.md
@@ -38,7 +38,7 @@ sauf si une fiche indique des réglages locaux différents.
 <dl class="mc-community-facts">
 <div><dt>Réglages</dt>
 <dd>Réglages par défaut du Canada</dd></div>
-<div><dt>Dernière vérification</dt>
+<div><dt>Fiche révisée</dt>
 <dd>2026-08-29</dd></div>
 </dl>
 <h4>Coordonnées</h4>
@@ -48,7 +48,7 @@ sauf si une fiche indique des réglages locaux différents.
 <p class="mc-community-contact-health">
 <strong>Vérification :</strong> Effectuée le 2026-08-29
 </p>
-<p class="mc-community-card__action"><a href="../../submit-idea/">Mettre cette fiche à jour</a></p>
+<p class="mc-community-card__action"><a href="../../submit-idea/?community=lunenburg-county-mesh&amp;source_page=https%3A%2F%2Fmeshcore.ca%2Ffr%2Fprovinces%2Fnova-scotia%2F%23community-lunenburg-county-mesh">Mettre cette fiche à jour</a></p>
 </article>
 </div>
 

--- a/docs/provinces/nova-scotia.md
+++ b/docs/provinces/nova-scotia.md
@@ -38,7 +38,7 @@ card lists different local settings.
 <dl class="mc-community-facts">
 <div><dt>Settings</dt>
 <dd>Uses the Canada defaults</dd></div>
-<div><dt>Last verified</dt>
+<div><dt>Listing reviewed</dt>
 <dd>2026-08-29</dd></div>
 </dl>
 <h4>Contacts</h4>
@@ -46,9 +46,9 @@ card lists different local settings.
 <li><strong>Website:</strong> <a href="http://www.lunenburgcountymesh.ca" rel="noopener">Lunenburg County Mesh website</a> <span class="mc-community-external">(external)</span></li>
 </ul>
 <p class="mc-community-contact-health">
-<strong>Contact check:</strong> Verified on 2026-08-29
+<strong>Contact check:</strong> Links checked on 2026-08-29
 </p>
-<p class="mc-community-card__action"><a href="../../submit-idea/">Update this listing</a></p>
+<p class="mc-community-card__action"><a href="../../submit-idea/?community=lunenburg-county-mesh&amp;source_page=https%3A%2F%2Fmeshcore.ca%2Fprovinces%2Fnova-scotia%2F%23community-lunenburg-county-mesh">Update this listing</a></p>
 </article>
 </div>
 

--- a/docs/provinces/ontario.fr.md
+++ b/docs/provinces/ontario.fr.md
@@ -38,7 +38,7 @@ sauf si une fiche indique des réglages locaux différents.
 <dl class="mc-community-facts">
 <div><dt>Réglages</dt>
 <dd>Réglages par défaut du Canada</dd></div>
-<div><dt>Dernière vérification</dt>
+<div><dt>Fiche révisée</dt>
 <dd>2026-08-29</dd></div>
 </dl>
 <h4>Coordonnées</h4>
@@ -49,7 +49,7 @@ sauf si une fiche indique des réglages locaux différents.
 <p class="mc-community-contact-health">
 <strong>Vérification :</strong> Effectuée le 2026-08-29
 </p>
-<p class="mc-community-card__action"><a href="../../submit-idea/">Mettre cette fiche à jour</a></p>
+<p class="mc-community-card__action"><a href="../../submit-idea/?community=greater-ottawa-mesh-enthusiasts&amp;source_page=https%3A%2F%2Fmeshcore.ca%2Ffr%2Fprovinces%2Fontario%2F%23community-greater-ottawa-mesh-enthusiasts">Mettre cette fiche à jour</a></p>
 </article>
 <article class="mc-community-card mc-community-card--detail" id="community-gta-lora-meshes">
 <div class="mc-community-card__header">
@@ -60,7 +60,7 @@ sauf si une fiche indique des réglages locaux différents.
 <dl class="mc-community-facts">
 <div><dt>Réglages</dt>
 <dd>Réglages par défaut du Canada</dd></div>
-<div><dt>Dernière vérification</dt>
+<div><dt>Fiche révisée</dt>
 <dd>2026-08-29</dd></div>
 </dl>
 <h4>Coordonnées</h4>
@@ -70,7 +70,7 @@ sauf si une fiche indique des réglages locaux différents.
 <p class="mc-community-contact-health">
 <strong>Vérification :</strong> Effectuée le 2026-08-29
 </p>
-<p class="mc-community-card__action"><a href="../../submit-idea/">Mettre cette fiche à jour</a></p>
+<p class="mc-community-card__action"><a href="../../submit-idea/?community=gta-lora-meshes&amp;source_page=https%3A%2F%2Fmeshcore.ca%2Ffr%2Fprovinces%2Fontario%2F%23community-gta-lora-meshes">Mettre cette fiche à jour</a></p>
 </article>
 <article class="mc-community-card mc-community-card--detail" id="community-quinte-mesh-network">
 <div class="mc-community-card__header">
@@ -81,7 +81,7 @@ sauf si une fiche indique des réglages locaux différents.
 <dl class="mc-community-facts">
 <div><dt>Réglages</dt>
 <dd>Réglages par défaut du Canada</dd></div>
-<div><dt>Dernière vérification</dt>
+<div><dt>Fiche révisée</dt>
 <dd>2026-08-29</dd></div>
 </dl>
 <h4>Coordonnées</h4>
@@ -92,7 +92,7 @@ sauf si une fiche indique des réglages locaux différents.
 <p class="mc-community-contact-health">
 <strong>Vérification :</strong> Effectuée le 2026-08-29
 </p>
-<p class="mc-community-card__action"><a href="../../submit-idea/">Mettre cette fiche à jour</a></p>
+<p class="mc-community-card__action"><a href="../../submit-idea/?community=quinte-mesh-network&amp;source_page=https%3A%2F%2Fmeshcore.ca%2Ffr%2Fprovinces%2Fontario%2F%23community-quinte-mesh-network">Mettre cette fiche à jour</a></p>
 </article>
 </div>
 

--- a/docs/provinces/ontario.md
+++ b/docs/provinces/ontario.md
@@ -38,7 +38,7 @@ card lists different local settings.
 <dl class="mc-community-facts">
 <div><dt>Settings</dt>
 <dd>Uses the Canada defaults</dd></div>
-<div><dt>Last verified</dt>
+<div><dt>Listing reviewed</dt>
 <dd>2026-08-29</dd></div>
 </dl>
 <h4>Contacts</h4>
@@ -47,9 +47,9 @@ card lists different local settings.
 <li><strong>Website:</strong> <a href="https://ottawamesh.ca/" rel="noopener">Ottawa Mesh website</a> <span class="mc-community-external">(external)</span></li>
 </ul>
 <p class="mc-community-contact-health">
-<strong>Contact check:</strong> Verified on 2026-08-29
+<strong>Contact check:</strong> Links checked on 2026-08-29
 </p>
-<p class="mc-community-card__action"><a href="../../submit-idea/">Update this listing</a></p>
+<p class="mc-community-card__action"><a href="../../submit-idea/?community=greater-ottawa-mesh-enthusiasts&amp;source_page=https%3A%2F%2Fmeshcore.ca%2Fprovinces%2Fontario%2F%23community-greater-ottawa-mesh-enthusiasts">Update this listing</a></p>
 </article>
 <article class="mc-community-card mc-community-card--detail" id="community-gta-lora-meshes">
 <div class="mc-community-card__header">
@@ -60,7 +60,7 @@ card lists different local settings.
 <dl class="mc-community-facts">
 <div><dt>Settings</dt>
 <dd>Uses the Canada defaults</dd></div>
-<div><dt>Last verified</dt>
+<div><dt>Listing reviewed</dt>
 <dd>2026-08-29</dd></div>
 </dl>
 <h4>Contacts</h4>
@@ -68,9 +68,9 @@ card lists different local settings.
 <li><strong>Discord:</strong> <a href="https://discord.gg/wSHbeb86r4" rel="noopener">GTA+-Lora-Meshes Discord</a> <span class="mc-community-external">(external)</span></li>
 </ul>
 <p class="mc-community-contact-health">
-<strong>Contact check:</strong> Verified on 2026-08-29
+<strong>Contact check:</strong> Links checked on 2026-08-29
 </p>
-<p class="mc-community-card__action"><a href="../../submit-idea/">Update this listing</a></p>
+<p class="mc-community-card__action"><a href="../../submit-idea/?community=gta-lora-meshes&amp;source_page=https%3A%2F%2Fmeshcore.ca%2Fprovinces%2Fontario%2F%23community-gta-lora-meshes">Update this listing</a></p>
 </article>
 <article class="mc-community-card mc-community-card--detail" id="community-quinte-mesh-network">
 <div class="mc-community-card__header">
@@ -81,7 +81,7 @@ card lists different local settings.
 <dl class="mc-community-facts">
 <div><dt>Settings</dt>
 <dd>Uses the Canada defaults</dd></div>
-<div><dt>Last verified</dt>
+<div><dt>Listing reviewed</dt>
 <dd>2026-08-29</dd></div>
 </dl>
 <h4>Contacts</h4>
@@ -90,9 +90,9 @@ card lists different local settings.
 <li><strong>Website:</strong> <a href="https://quintemesh.ca/" rel="noopener">Quinte Mesh Network website</a> <span class="mc-community-external">(external)</span></li>
 </ul>
 <p class="mc-community-contact-health">
-<strong>Contact check:</strong> Verified on 2026-08-29
+<strong>Contact check:</strong> Links checked on 2026-08-29
 </p>
-<p class="mc-community-card__action"><a href="../../submit-idea/">Update this listing</a></p>
+<p class="mc-community-card__action"><a href="../../submit-idea/?community=quinte-mesh-network&amp;source_page=https%3A%2F%2Fmeshcore.ca%2Fprovinces%2Fontario%2F%23community-quinte-mesh-network">Update this listing</a></p>
 </article>
 </div>
 

--- a/docs/provinces/quebec.fr.md
+++ b/docs/provinces/quebec.fr.md
@@ -38,7 +38,7 @@ sauf si une fiche indique des réglages locaux différents.
 <dl class="mc-community-facts">
 <div><dt>Réglages</dt>
 <dd>Réglages par défaut du Canada</dd></div>
-<div><dt>Dernière vérification</dt>
+<div><dt>Fiche révisée</dt>
 <dd>2026-08-29</dd></div>
 </dl>
 <h4>Coordonnées</h4>
@@ -49,7 +49,7 @@ sauf si une fiche indique des réglages locaux différents.
 <p class="mc-community-contact-health">
 <strong>Vérification :</strong> Effectuée le 2026-08-29
 </p>
-<p class="mc-community-card__action"><a href="../../submit-idea/">Mettre cette fiche à jour</a></p>
+<p class="mc-community-card__action"><a href="../../submit-idea/?community=charlevoix-yml&amp;source_page=https%3A%2F%2Fmeshcore.ca%2Ffr%2Fprovinces%2Fquebec%2F%23community-charlevoix-yml">Mettre cette fiche à jour</a></p>
 </article>
 <article class="mc-community-card mc-community-card--detail" id="community-mesh-quebec">
 <div class="mc-community-card__header">
@@ -60,7 +60,7 @@ sauf si une fiche indique des réglages locaux différents.
 <dl class="mc-community-facts">
 <div><dt>Réglages</dt>
 <dd>Réglages par défaut du Canada</dd></div>
-<div><dt>Dernière vérification</dt>
+<div><dt>Fiche révisée</dt>
 <dd>2026-08-29</dd></div>
 </dl>
 <h4>Coordonnées</h4>
@@ -70,7 +70,7 @@ sauf si une fiche indique des réglages locaux différents.
 <p class="mc-community-contact-health">
 <strong>Vérification :</strong> Effectuée le 2026-08-29
 </p>
-<p class="mc-community-card__action"><a href="../../submit-idea/">Mettre cette fiche à jour</a></p>
+<p class="mc-community-card__action"><a href="../../submit-idea/?community=mesh-quebec&amp;source_page=https%3A%2F%2Fmeshcore.ca%2Ffr%2Fprovinces%2Fquebec%2F%23community-mesh-quebec">Mettre cette fiche à jour</a></p>
 </article>
 <article class="mc-community-card mc-community-card--detail" id="community-montreal-mesh">
 <div class="mc-community-card__header">
@@ -81,7 +81,7 @@ sauf si une fiche indique des réglages locaux différents.
 <dl class="mc-community-facts">
 <div><dt>Réglages</dt>
 <dd>Réglages par défaut du Canada</dd></div>
-<div><dt>Dernière vérification</dt>
+<div><dt>Fiche révisée</dt>
 <dd>2026-08-29</dd></div>
 </dl>
 <h4>Coordonnées</h4>
@@ -91,7 +91,7 @@ sauf si une fiche indique des réglages locaux différents.
 <p class="mc-community-contact-health">
 <strong>Vérification :</strong> Effectuée le 2026-08-29
 </p>
-<p class="mc-community-card__action"><a href="../../submit-idea/">Mettre cette fiche à jour</a></p>
+<p class="mc-community-card__action"><a href="../../submit-idea/?community=montreal-mesh&amp;source_page=https%3A%2F%2Fmeshcore.ca%2Ffr%2Fprovinces%2Fquebec%2F%23community-montreal-mesh">Mettre cette fiche à jour</a></p>
 </article>
 <article class="mc-community-card mc-community-card--detail" id="community-reseau-mesh-capitale-yqb">
 <div class="mc-community-card__header">
@@ -102,7 +102,7 @@ sauf si une fiche indique des réglages locaux différents.
 <dl class="mc-community-facts">
 <div><dt>Réglages</dt>
 <dd>Réglages par défaut du Canada</dd></div>
-<div><dt>Dernière vérification</dt>
+<div><dt>Fiche révisée</dt>
 <dd>2026-08-29</dd></div>
 </dl>
 <h4>Coordonnées</h4>
@@ -112,7 +112,7 @@ sauf si une fiche indique des réglages locaux différents.
 <p class="mc-community-contact-health">
 <strong>Vérification :</strong> Effectuée le 2026-08-29
 </p>
-<p class="mc-community-card__action"><a href="../../submit-idea/">Mettre cette fiche à jour</a></p>
+<p class="mc-community-card__action"><a href="../../submit-idea/?community=reseau-mesh-capitale-yqb&amp;source_page=https%3A%2F%2Fmeshcore.ca%2Ffr%2Fprovinces%2Fquebec%2F%23community-reseau-mesh-capitale-yqb">Mettre cette fiche à jour</a></p>
 </article>
 <article class="mc-community-card mc-community-card--detail" id="community-reseau-mesh-saguenay-lac-saint-jean-ytf">
 <div class="mc-community-card__header">
@@ -123,7 +123,7 @@ sauf si une fiche indique des réglages locaux différents.
 <dl class="mc-community-facts">
 <div><dt>Réglages</dt>
 <dd>Réglages par défaut du Canada</dd></div>
-<div><dt>Dernière vérification</dt>
+<div><dt>Fiche révisée</dt>
 <dd>2026-08-29</dd></div>
 </dl>
 <h4>Coordonnées</h4>
@@ -134,7 +134,7 @@ sauf si une fiche indique des réglages locaux différents.
 <p class="mc-community-contact-health">
 <strong>Vérification :</strong> Certains liens restent à vérifier
 </p>
-<p class="mc-community-card__action"><a href="../../submit-idea/">Mettre cette fiche à jour</a></p>
+<p class="mc-community-card__action"><a href="../../submit-idea/?community=reseau-mesh-saguenay-lac-saint-jean-ytf&amp;source_page=https%3A%2F%2Fmeshcore.ca%2Ffr%2Fprovinces%2Fquebec%2F%23community-reseau-mesh-saguenay-lac-saint-jean-ytf">Mettre cette fiche à jour</a></p>
 </article>
 <article class="mc-community-card mc-community-card--detail" id="community-reseau-libre">
 <div class="mc-community-card__header">
@@ -145,7 +145,7 @@ sauf si une fiche indique des réglages locaux différents.
 <dl class="mc-community-facts">
 <div><dt>Réglages</dt>
 <dd>Réglages par défaut du Canada</dd></div>
-<div><dt>Dernière vérification</dt>
+<div><dt>Fiche révisée</dt>
 <dd>2026-08-29</dd></div>
 </dl>
 <h4>Coordonnées</h4>
@@ -155,7 +155,7 @@ sauf si une fiche indique des réglages locaux différents.
 <p class="mc-community-contact-health">
 <strong>Vérification :</strong> Effectuée le 2026-08-29
 </p>
-<p class="mc-community-card__action"><a href="../../submit-idea/">Mettre cette fiche à jour</a></p>
+<p class="mc-community-card__action"><a href="../../submit-idea/?community=reseau-libre&amp;source_page=https%3A%2F%2Fmeshcore.ca%2Ffr%2Fprovinces%2Fquebec%2F%23community-reseau-libre">Mettre cette fiche à jour</a></p>
 </article>
 </div>
 

--- a/docs/provinces/quebec.md
+++ b/docs/provinces/quebec.md
@@ -38,7 +38,7 @@ card lists different local settings.
 <dl class="mc-community-facts">
 <div><dt>Settings</dt>
 <dd>Uses the Canada defaults</dd></div>
-<div><dt>Last verified</dt>
+<div><dt>Listing reviewed</dt>
 <dd>2026-08-29</dd></div>
 </dl>
 <h4>Contacts</h4>
@@ -47,9 +47,9 @@ card lists different local settings.
 </ul>
 <p class="mc-community-owner"><strong>Listing contact:</strong> pifane</p>
 <p class="mc-community-contact-health">
-<strong>Contact check:</strong> Verified on 2026-08-29
+<strong>Contact check:</strong> Links checked on 2026-08-29
 </p>
-<p class="mc-community-card__action"><a href="../../submit-idea/">Update this listing</a></p>
+<p class="mc-community-card__action"><a href="../../submit-idea/?community=charlevoix-yml&amp;source_page=https%3A%2F%2Fmeshcore.ca%2Fprovinces%2Fquebec%2F%23community-charlevoix-yml">Update this listing</a></p>
 </article>
 <article class="mc-community-card mc-community-card--detail" id="community-mesh-quebec">
 <div class="mc-community-card__header">
@@ -60,7 +60,7 @@ card lists different local settings.
 <dl class="mc-community-facts">
 <div><dt>Settings</dt>
 <dd>Uses the Canada defaults</dd></div>
-<div><dt>Last verified</dt>
+<div><dt>Listing reviewed</dt>
 <dd>2026-08-29</dd></div>
 </dl>
 <h4>Contacts</h4>
@@ -68,9 +68,9 @@ card lists different local settings.
 <li><strong>Telegram:</strong> <a href="https://t.me/meshtQuebec" rel="noopener">Mesh Quebec Telegram</a> <span class="mc-community-external">(external)</span></li>
 </ul>
 <p class="mc-community-contact-health">
-<strong>Contact check:</strong> Verified on 2026-08-29
+<strong>Contact check:</strong> Links checked on 2026-08-29
 </p>
-<p class="mc-community-card__action"><a href="../../submit-idea/">Update this listing</a></p>
+<p class="mc-community-card__action"><a href="../../submit-idea/?community=mesh-quebec&amp;source_page=https%3A%2F%2Fmeshcore.ca%2Fprovinces%2Fquebec%2F%23community-mesh-quebec">Update this listing</a></p>
 </article>
 <article class="mc-community-card mc-community-card--detail" id="community-montreal-mesh">
 <div class="mc-community-card__header">
@@ -81,7 +81,7 @@ card lists different local settings.
 <dl class="mc-community-facts">
 <div><dt>Settings</dt>
 <dd>Uses the Canada defaults</dd></div>
-<div><dt>Last verified</dt>
+<div><dt>Listing reviewed</dt>
 <dd>2026-08-29</dd></div>
 </dl>
 <h4>Contacts</h4>
@@ -89,9 +89,9 @@ card lists different local settings.
 <li><strong>Website:</strong> <a href="https://www.montrealmesh.ca" rel="noopener">Montreal Mesh website</a> <span class="mc-community-external">(external)</span></li>
 </ul>
 <p class="mc-community-contact-health">
-<strong>Contact check:</strong> Verified on 2026-08-29
+<strong>Contact check:</strong> Links checked on 2026-08-29
 </p>
-<p class="mc-community-card__action"><a href="../../submit-idea/">Update this listing</a></p>
+<p class="mc-community-card__action"><a href="../../submit-idea/?community=montreal-mesh&amp;source_page=https%3A%2F%2Fmeshcore.ca%2Fprovinces%2Fquebec%2F%23community-montreal-mesh">Update this listing</a></p>
 </article>
 <article class="mc-community-card mc-community-card--detail" id="community-reseau-mesh-capitale-yqb">
 <div class="mc-community-card__header">
@@ -102,7 +102,7 @@ card lists different local settings.
 <dl class="mc-community-facts">
 <div><dt>Settings</dt>
 <dd>Uses the Canada defaults</dd></div>
-<div><dt>Last verified</dt>
+<div><dt>Listing reviewed</dt>
 <dd>2026-08-29</dd></div>
 </dl>
 <h4>Contacts</h4>
@@ -110,9 +110,9 @@ card lists different local settings.
 <li><strong>Discord:</strong> <a href="https://discord.gg/UhGjTF2MfA" rel="noopener">Réseau Mesh de la Capitale YQB Discord</a> <span class="mc-community-external">(external)</span></li>
 </ul>
 <p class="mc-community-contact-health">
-<strong>Contact check:</strong> Verified on 2026-08-29
+<strong>Contact check:</strong> Links checked on 2026-08-29
 </p>
-<p class="mc-community-card__action"><a href="../../submit-idea/">Update this listing</a></p>
+<p class="mc-community-card__action"><a href="../../submit-idea/?community=reseau-mesh-capitale-yqb&amp;source_page=https%3A%2F%2Fmeshcore.ca%2Fprovinces%2Fquebec%2F%23community-reseau-mesh-capitale-yqb">Update this listing</a></p>
 </article>
 <article class="mc-community-card mc-community-card--detail" id="community-reseau-mesh-saguenay-lac-saint-jean-ytf">
 <div class="mc-community-card__header">
@@ -123,7 +123,7 @@ card lists different local settings.
 <dl class="mc-community-facts">
 <div><dt>Settings</dt>
 <dd>Uses the Canada defaults</dd></div>
-<div><dt>Last verified</dt>
+<div><dt>Listing reviewed</dt>
 <dd>2026-08-29</dd></div>
 </dl>
 <h4>Contacts</h4>
@@ -134,7 +134,7 @@ card lists different local settings.
 <p class="mc-community-contact-health">
 <strong>Contact check:</strong> Some links still need review
 </p>
-<p class="mc-community-card__action"><a href="../../submit-idea/">Update this listing</a></p>
+<p class="mc-community-card__action"><a href="../../submit-idea/?community=reseau-mesh-saguenay-lac-saint-jean-ytf&amp;source_page=https%3A%2F%2Fmeshcore.ca%2Fprovinces%2Fquebec%2F%23community-reseau-mesh-saguenay-lac-saint-jean-ytf">Update this listing</a></p>
 </article>
 <article class="mc-community-card mc-community-card--detail" id="community-reseau-libre">
 <div class="mc-community-card__header">
@@ -145,7 +145,7 @@ card lists different local settings.
 <dl class="mc-community-facts">
 <div><dt>Settings</dt>
 <dd>Uses the Canada defaults</dd></div>
-<div><dt>Last verified</dt>
+<div><dt>Listing reviewed</dt>
 <dd>2026-08-29</dd></div>
 </dl>
 <h4>Contacts</h4>
@@ -153,9 +153,9 @@ card lists different local settings.
 <li><strong>Website:</strong> <a href="https://lora.reseaulibre.ca/" rel="noopener">Réseau Libre website</a> <span class="mc-community-external">(external)</span></li>
 </ul>
 <p class="mc-community-contact-health">
-<strong>Contact check:</strong> Verified on 2026-08-29
+<strong>Contact check:</strong> Links checked on 2026-08-29
 </p>
-<p class="mc-community-card__action"><a href="../../submit-idea/">Update this listing</a></p>
+<p class="mc-community-card__action"><a href="../../submit-idea/?community=reseau-libre&amp;source_page=https%3A%2F%2Fmeshcore.ca%2Fprovinces%2Fquebec%2F%23community-reseau-libre">Update this listing</a></p>
 </article>
 </div>
 

--- a/docs/provinces/saskatchewan.fr.md
+++ b/docs/provinces/saskatchewan.fr.md
@@ -38,7 +38,7 @@ sauf si une fiche indique des réglages locaux différents.
 <dl class="mc-community-facts">
 <div><dt>Réglages</dt>
 <dd>Réglages par défaut du Canada</dd></div>
-<div><dt>Dernière vérification</dt>
+<div><dt>Fiche révisée</dt>
 <dd>2026-08-29</dd></div>
 </dl>
 <h4>Coordonnées</h4>
@@ -48,7 +48,7 @@ sauf si une fiche indique des réglages locaux différents.
 <p class="mc-community-contact-health">
 <strong>Vérification :</strong> Effectuée le 2026-08-29
 </p>
-<p class="mc-community-card__action"><a href="../../submit-idea/">Mettre cette fiche à jour</a></p>
+<p class="mc-community-card__action"><a href="../../submit-idea/?community=stoonmesh&amp;source_page=https%3A%2F%2Fmeshcore.ca%2Ffr%2Fprovinces%2Fsaskatchewan%2F%23community-stoonmesh">Mettre cette fiche à jour</a></p>
 </article>
 <article class="mc-community-card mc-community-card--detail" id="community-yqrmesh">
 <div class="mc-community-card__header">
@@ -59,11 +59,11 @@ sauf si une fiche indique des réglages locaux différents.
 <dl class="mc-community-facts">
 <div><dt>Réglages</dt>
 <dd>Réglages par défaut du Canada</dd></div>
-<div><dt>Dernière vérification</dt>
+<div><dt>Fiche révisée</dt>
 <dd>2026-08-29</dd></div>
 </dl>
 <p class="mc-community-no-contact">Aucune coordonnée publique n’a encore été fournie.</p>
-<p class="mc-community-card__action"><a href="../../submit-idea/">Mettre cette fiche à jour</a></p>
+<p class="mc-community-card__action"><a href="../../submit-idea/?community=yqrmesh&amp;source_page=https%3A%2F%2Fmeshcore.ca%2Ffr%2Fprovinces%2Fsaskatchewan%2F%23community-yqrmesh">Mettre cette fiche à jour</a></p>
 </article>
 </div>
 

--- a/docs/provinces/saskatchewan.md
+++ b/docs/provinces/saskatchewan.md
@@ -38,7 +38,7 @@ card lists different local settings.
 <dl class="mc-community-facts">
 <div><dt>Settings</dt>
 <dd>Uses the Canada defaults</dd></div>
-<div><dt>Last verified</dt>
+<div><dt>Listing reviewed</dt>
 <dd>2026-08-29</dd></div>
 </dl>
 <h4>Contacts</h4>
@@ -46,9 +46,9 @@ card lists different local settings.
 <li><strong>Telegram:</strong> <a href="https://t.me/MeshtSaska" rel="noopener">Mesh Saskatchewan Telegram</a> <span class="mc-community-external">(external)</span></li>
 </ul>
 <p class="mc-community-contact-health">
-<strong>Contact check:</strong> Verified on 2026-08-29
+<strong>Contact check:</strong> Links checked on 2026-08-29
 </p>
-<p class="mc-community-card__action"><a href="../../submit-idea/">Update this listing</a></p>
+<p class="mc-community-card__action"><a href="../../submit-idea/?community=stoonmesh&amp;source_page=https%3A%2F%2Fmeshcore.ca%2Fprovinces%2Fsaskatchewan%2F%23community-stoonmesh">Update this listing</a></p>
 </article>
 <article class="mc-community-card mc-community-card--detail" id="community-yqrmesh">
 <div class="mc-community-card__header">
@@ -59,11 +59,11 @@ card lists different local settings.
 <dl class="mc-community-facts">
 <div><dt>Settings</dt>
 <dd>Uses the Canada defaults</dd></div>
-<div><dt>Last verified</dt>
+<div><dt>Listing reviewed</dt>
 <dd>2026-08-29</dd></div>
 </dl>
 <p class="mc-community-no-contact">No public contact has been provided yet.</p>
-<p class="mc-community-card__action"><a href="../../submit-idea/">Update this listing</a></p>
+<p class="mc-community-card__action"><a href="../../submit-idea/?community=yqrmesh&amp;source_page=https%3A%2F%2Fmeshcore.ca%2Fprovinces%2Fsaskatchewan%2F%23community-yqrmesh">Update this listing</a></p>
 </article>
 </div>
 

--- a/docs/resources/glossary.fr.md
+++ b/docs/resources/glossary.fr.md
@@ -91,9 +91,8 @@ utiliser chaque paramètre ou appareil.
 :   Tout appareil MeshCore présent sur le réseau.
 
 **Observateur**
-:   Une radio ou un service sur un système hôte qui écoute le trafic MeshCore
-    et transmet des données du réseau aux outils publics. Il ne relaie pas le
-    trafic du réseau.
+:   Une radio ou un service qui transmet des données MeshCore aux outils publics.
+    L’observation et la répétition sont des fonctions distinctes; un appareil peut faire les deux.
 
 **Préréglage**
 :   Un ensemble nommé de paramètres radio.

--- a/docs/resources/glossary.md
+++ b/docs/resources/glossary.md
@@ -83,7 +83,7 @@ the linked guides explain how to use each setting or device.
 
 **Observer**
 :   A radio or host service that listens for MeshCore traffic and sends network
-    data to public tools. It does not relay mesh traffic.
+    data to public tools. Observing and repeating are separate functions; a node can do both when configured for it.
 
 **Path hash mode**
 :   The MeshCore setting that controls the size of identifiers in advert paths.

--- a/docs/start/companion.fr.md
+++ b/docs/start/companion.fr.md
@@ -26,6 +26,8 @@ Un appareil compagnon sert à envoyer et à recevoir des messages personnels. Il
 ne relaie pas le trafic des autres personnes. La plupart se jumellent à une
 application; certains possèdent leur propre écran et leurs propres commandes.
 
+[Installer et configurer un compagnon](../meshcore/flash-companion.md){ .md-button .md-button--primary }
+
 ## Avant de commencer
 
 - Consultez les [appareils compagnons recommandés](../hardware/recommended-companions.md).
@@ -40,25 +42,11 @@ Le guide lié remplace le micrologiciel de l’appareil et le configure comme
 compagnon. Arrêtez-vous avant l’effacement si vous ne pouvez pas récupérer les
 renseignements dont vous avez besoin.
 
-<section class="mc-start-progress" data-mc-progress-page="companion" aria-labelledby="companion-progress-title">
-  <h2 id="companion-progress-title">Liste de configuration</h2>
-  <p>Cette liste est enregistrée uniquement dans ce navigateur.</p>
-  <ol>
-    <li><label><input id="companion-progress-hardware" type="checkbox" data-mc-progress> Confirmer que le matériel est compatible</label></li>
-    <li><label><input id="companion-progress-prepare" type="checkbox" data-mc-progress> Sauvegarder les données et préparer l’appareil</label></li>
-    <li><label><input id="companion-progress-flash" type="checkbox" data-mc-progress> Suivre le guide d’installation du micrologiciel</label></li>
-    <li><label><input id="companion-progress-configure" type="checkbox" data-mc-progress> Appliquer les paramètres du Canada ou de la communauté</label></li>
-    <li><label><input id="companion-progress-verify-local" type="checkbox" data-mc-progress> Vérifier l’appareil à proximité</label></li>
-    <li><label><input id="companion-progress-verify-community" type="checkbox" data-mc-progress> Faire un essai avec une autre personne du réseau</label></li>
-  </ol>
-</section>
+
 
 ## Installer le micrologiciel du compagnon
 
-Suivez le guide [Reprogrammer et configurer un appareil
-compagnon](../meshcore/flash-companion.md). Il explique comment choisir
-l’appareil, établir la connexion dans le navigateur, installer le micrologiciel
-et récupérer l’appareil en cas de problème.
+Suivez le guide [Installer et configurer un compagnon](../meshcore/flash-companion.md).
 
 ## Choisir les bons paramètres radio
 
@@ -89,3 +77,16 @@ modification du micrologiciel. Consultez les
 messagerie courantes. [Trouvez votre communauté](../provinces/index.md), puis
 échangez un message d’essai avec une personne à proximité. Si personne ne voit
 l’annonce, [obtenez de l’aide](get-help.md).
+
+<section class="mc-start-progress" data-mc-progress-page="companion" aria-labelledby="companion-progress-title">
+  <h2 id="companion-progress-title">Liste de vérification</h2>
+  <p>Cette liste est enregistrée uniquement dans ce navigateur.</p>
+  <ol>
+    <li><label><input id="companion-progress-hardware" type="checkbox" data-mc-progress> Confirmer que le matériel est compatible</label></li>
+    <li><label><input id="companion-progress-prepare" type="checkbox" data-mc-progress> Sauvegarder les données et préparer l’appareil</label></li>
+    <li><label><input id="companion-progress-flash" type="checkbox" data-mc-progress> Suivre le guide d’installation du micrologiciel</label></li>
+    <li><label><input id="companion-progress-configure" type="checkbox" data-mc-progress> Appliquer les paramètres du Canada ou de la communauté</label></li>
+    <li><label><input id="companion-progress-verify-local" type="checkbox" data-mc-progress> Vérifier l’appareil à proximité</label></li>
+    <li><label><input id="companion-progress-verify-community" type="checkbox" data-mc-progress> Faire un essai avec une autre personne du réseau</label></li>
+  </ol>
+</section>

--- a/docs/start/companion.md
+++ b/docs/start/companion.md
@@ -25,6 +25,8 @@ requires:
 A companion is a personal messaging device. It does not route traffic for
 other users. Most pair with an app; some have their own screen and controls.
 
+[Install and configure a companion](../meshcore/flash-companion.md){ .md-button .md-button--primary }
+
 ## Before you start
 
 - Check the [recommended companion options](../hardware/recommended-companions.md).
@@ -37,24 +39,11 @@ other users. Most pair with an app; some have their own screen and controls.
 The linked flashing guide replaces the device firmware and configures it as a
 companion. Stop before erasing if you cannot recover information you need.
 
-<section class="mc-start-progress" data-mc-progress-page="companion" aria-labelledby="companion-progress-title">
-  <h2 id="companion-progress-title">Setup checklist</h2>
-  <p>Checks are saved only in this browser.</p>
-  <ol>
-    <li><label><input id="companion-progress-hardware" type="checkbox" data-mc-progress> Confirm compatible hardware</label></li>
-    <li><label><input id="companion-progress-prepare" type="checkbox" data-mc-progress> Back up and prepare</label></li>
-    <li><label><input id="companion-progress-flash" type="checkbox" data-mc-progress> Follow the flashing guide</label></li>
-    <li><label><input id="companion-progress-configure" type="checkbox" data-mc-progress> Apply Canada or local settings</label></li>
-    <li><label><input id="companion-progress-verify-local" type="checkbox" data-mc-progress> Check the device nearby</label></li>
-    <li><label><input id="companion-progress-verify-community" type="checkbox" data-mc-progress> Test with another mesh user</label></li>
-  </ol>
-</section>
+
 
 ## Flash the companion
 
-Follow [Flash and configure a companion](../meshcore/flash-companion.md). Use
-that guide for device selection, browser connection, flashing, and recovery
-steps.
+Follow [Flash and configure a companion](../meshcore/flash-companion.md).
 
 ## Use the right radio settings
 
@@ -75,6 +64,19 @@ The companion is ready when:
 2. a nearby known-good device or community member can see its advert.
 
 Use the [companion verification checklist](verify.md#companion).
+
+<section class="mc-start-progress" data-mc-progress-page="companion" aria-labelledby="companion-progress-title">
+  <h2 id="companion-progress-title">Setup checklist</h2>
+  <p>Checks are saved only in this browser.</p>
+  <ol>
+    <li><label><input id="companion-progress-hardware" type="checkbox" data-mc-progress> Confirm compatible hardware</label></li>
+    <li><label><input id="companion-progress-prepare" type="checkbox" data-mc-progress> Back up and prepare</label></li>
+    <li><label><input id="companion-progress-flash" type="checkbox" data-mc-progress> Follow the flashing guide</label></li>
+    <li><label><input id="companion-progress-configure" type="checkbox" data-mc-progress> Apply Canada or local settings</label></li>
+    <li><label><input id="companion-progress-verify-local" type="checkbox" data-mc-progress> Check the device nearby</label></li>
+    <li><label><input id="companion-progress-verify-community" type="checkbox" data-mc-progress> Test with another mesh user</label></li>
+  </ol>
+</section>
 
 ## What's next
 

--- a/docs/start/observer.fr.md
+++ b/docs/start/observer.fr.md
@@ -23,12 +23,15 @@ requires:
 # Commencer avec un observateur
 
 Un observateur écoute le réseau au moyen d’une radio MeshCore et transmet les
-données captées à CoreScope. Il ne relaie pas le trafic du réseau. Il peut
+données captées à CoreScope. Il n’a pas besoin de relayer le trafic, mais un
+même appareil peut remplir les deux fonctions. Il peut
 fonctionner dans le micrologiciel d’une radio, sur un ordinateur qui reste
 allumé ou sur un système de domotique.
 
 Avant de l’activer, lisez
 [quelles données le service recueille et qui peut y accéder](../analyzer/data-collection-access.md).
+
+[Choisir une méthode d’observation](../analyzer/intro.md){ .md-button .md-button--primary }
 
 ## Avant de commencer
 
@@ -46,19 +49,7 @@ Selon la méthode choisie, la configuration peut remplacer le micrologiciel de
 la radio, installer un service sur le système hôte ou ajouter une intégration
 domotique. Elle permet aussi la transmission publique de données du réseau.
 
-<section class="mc-start-progress" data-mc-progress-page="observer" aria-labelledby="observer-progress-title">
-  <h2 id="observer-progress-title">Liste de configuration</h2>
-  <p>Cette liste est enregistrée uniquement dans ce navigateur.</p>
-  <ol>
-    <li><label><input id="observer-progress-privacy" type="checkbox" data-mc-progress> Lire quelles données de l’observateur deviennent publiques</label></li>
-    <li><label><input id="observer-progress-method" type="checkbox" data-mc-progress> Choisir une méthode d’observation prise en charge</label></li>
-    <li><label><input id="observer-progress-prepare" type="checkbox" data-mc-progress> Sauvegarder les données et préparer l’appareil</label></li>
-    <li><label><input id="observer-progress-install" type="checkbox" data-mc-progress> Suivre le guide de configuration choisi</label></li>
-    <li><label><input id="observer-progress-configure" type="checkbox" data-mc-progress> Appliquer les paramètres locaux de la radio et du service</label></li>
-    <li><label><input id="observer-progress-verify-local" type="checkbox" data-mc-progress> Vérifier que la radio capte l’activité à proximité</label></li>
-    <li><label><input id="observer-progress-verify-network" type="checkbox" data-mc-progress> Trouver l’observateur dans CoreScope</label></li>
-  </ol>
-</section>
+
 
 ## Configurer l’observateur
 
@@ -94,3 +85,17 @@ d’identifiants, de système hôte ou de micrologiciel. Ouvrez
 [Vérifier votre observateur](../analyzer/verify.md) pour consulter son état
 détaillé. S’il est absent ou silencieux,
 [obtenez de l’aide](get-help.md).
+
+<section class="mc-start-progress" data-mc-progress-page="observer" aria-labelledby="observer-progress-title">
+  <h2 id="observer-progress-title">Liste de vérification</h2>
+  <p>Cette liste est enregistrée uniquement dans ce navigateur.</p>
+  <ol>
+    <li><label><input id="observer-progress-privacy" type="checkbox" data-mc-progress> Lire quelles données de l’observateur deviennent publiques</label></li>
+    <li><label><input id="observer-progress-method" type="checkbox" data-mc-progress> Choisir une méthode d’observation prise en charge</label></li>
+    <li><label><input id="observer-progress-prepare" type="checkbox" data-mc-progress> Sauvegarder les données et préparer l’appareil</label></li>
+    <li><label><input id="observer-progress-install" type="checkbox" data-mc-progress> Suivre le guide de configuration choisi</label></li>
+    <li><label><input id="observer-progress-configure" type="checkbox" data-mc-progress> Appliquer les paramètres locaux de la radio et du service</label></li>
+    <li><label><input id="observer-progress-verify-local" type="checkbox" data-mc-progress> Vérifier que la radio capte l’activité à proximité</label></li>
+    <li><label><input id="observer-progress-verify-network" type="checkbox" data-mc-progress> Trouver l’observateur dans CoreScope</label></li>
+  </ol>
+</section>

--- a/docs/start/observer.md
+++ b/docs/start/observer.md
@@ -23,11 +23,13 @@ requires:
 # Start with an observer
 
 An observer listens through a MeshCore radio and sends network data to
-CoreScope. It does not route mesh traffic. It can run on radio firmware, an
-always-on computer, or a home-automation host.
+CoreScope. Observing does not require repeating; a node can do both if configured
+for it. Observers can run on radio firmware, an always-on computer, or a home-automation host.
 
 Read [what the service collects and who can access
 it](../analyzer/data-collection-access.md) before enabling an observer.
+
+[Choose an observer setup](../analyzer/intro.md){ .md-button .md-button--primary }
 
 ## Before you start
 
@@ -43,19 +45,7 @@ Depending on the method, setup may replace radio firmware, install a host
 service, or add a home-automation integration. It also enables public
 network data publishing.
 
-<section class="mc-start-progress" data-mc-progress-page="observer" aria-labelledby="observer-progress-title">
-  <h2 id="observer-progress-title">Setup checklist</h2>
-  <p>Checks are saved only in this browser.</p>
-  <ol>
-    <li><label><input id="observer-progress-privacy" type="checkbox" data-mc-progress> Read what observer data becomes public</label></li>
-    <li><label><input id="observer-progress-method" type="checkbox" data-mc-progress> Choose a supported observer method</label></li>
-    <li><label><input id="observer-progress-prepare" type="checkbox" data-mc-progress> Back up and prepare</label></li>
-    <li><label><input id="observer-progress-install" type="checkbox" data-mc-progress> Follow the selected setup guide</label></li>
-    <li><label><input id="observer-progress-configure" type="checkbox" data-mc-progress> Apply local radio and service settings</label></li>
-    <li><label><input id="observer-progress-verify-local" type="checkbox" data-mc-progress> Check that the radio hears nearby activity</label></li>
-    <li><label><input id="observer-progress-verify-network" type="checkbox" data-mc-progress> Find the observer in CoreScope</label></li>
-  </ol>
-</section>
+
 
 ## Set up the observer
 
@@ -83,6 +73,20 @@ The observer is working when:
 3. recent activity appears after a nearby transmission.
 
 Use the [observer verification checklist](verify.md#observer).
+
+<section class="mc-start-progress" data-mc-progress-page="observer" aria-labelledby="observer-progress-title">
+  <h2 id="observer-progress-title">Setup checklist</h2>
+  <p>Checks are saved only in this browser.</p>
+  <ol>
+    <li><label><input id="observer-progress-privacy" type="checkbox" data-mc-progress> Read what observer data becomes public</label></li>
+    <li><label><input id="observer-progress-method" type="checkbox" data-mc-progress> Choose a supported observer method</label></li>
+    <li><label><input id="observer-progress-prepare" type="checkbox" data-mc-progress> Back up and prepare</label></li>
+    <li><label><input id="observer-progress-install" type="checkbox" data-mc-progress> Follow the selected setup guide</label></li>
+    <li><label><input id="observer-progress-configure" type="checkbox" data-mc-progress> Apply local radio and service settings</label></li>
+    <li><label><input id="observer-progress-verify-local" type="checkbox" data-mc-progress> Check that the radio hears nearby activity</label></li>
+    <li><label><input id="observer-progress-verify-network" type="checkbox" data-mc-progress> Find the observer in CoreScope</label></li>
+  </ol>
+</section>
 
 ## What's next
 

--- a/docs/start/repeater.fr.md
+++ b/docs/start/repeater.fr.md
@@ -21,7 +21,7 @@ requires:
 page_styles:
   - assets/styles/repeater-hash-check.css?v=20260820-1
 page_scripts:
-  - assets/javascripts/repeater-hash-check.js?v=20260820-1
+  - assets/javascripts/repeater-hash-check.js?v=20260904-1
 ---
 
 # Commencer avec un répéteur
@@ -29,6 +29,8 @@ page_scripts:
 Un répéteur améliore la couverture en relayant le trafic des autres personnes.
 Puisqu’il s’agit d’une installation fixe, planifiez l’alimentation, l’antenne,
 l’accès et l’entretien avant de l’installer.
+
+[Installer et configurer un répéteur](../meshcore/flash-repeater.md){ .md-button .md-button--primary }
 
 ## Avant de commencer
 
@@ -44,25 +46,10 @@ Le guide installe le micrologiciel du répéteur et configure la radio,
 l’identité, les annonces et la région. Faites les essais sur l’établi avant
 toute installation difficile d’accès.
 
-<section class="mc-start-progress" data-mc-progress-page="repeater" aria-labelledby="repeater-progress-title">
-  <h2 id="repeater-progress-title">Liste de configuration</h2>
-  <p>Cette liste est enregistrée uniquement dans ce navigateur.</p>
-  <ol>
-    <li><label><input id="repeater-progress-hardware" type="checkbox" data-mc-progress> Confirmer que le matériel et l’emplacement conviennent</label></li>
-    <li><label><input id="repeater-progress-prepare" type="checkbox" data-mc-progress> Sauvegarder les données et préparer l’appareil</label></li>
-    <li><label><input id="repeater-progress-flash" type="checkbox" data-mc-progress> Suivre le guide d’installation du micrologiciel</label></li>
-    <li><label><input id="repeater-progress-configure" type="checkbox" data-mc-progress> Appliquer les paramètres locaux et régionaux</label></li>
-    <li><label><input id="repeater-progress-verify-local" type="checkbox" data-mc-progress> Vérifier le répéteur sur l’établi</label></li>
-    <li><label><input id="repeater-progress-verify-community" type="checkbox" data-mc-progress> Faire un essai avec un compagnon à proximité</label></li>
-  </ol>
-</section>
 
 ## Installer le micrologiciel du répéteur
 
-Suivez le guide [Reprogrammer et configurer un
-répéteur](../meshcore/flash-repeater.md). Il présente les choix propres à chaque
-carte, les sauvegardes à faire, les situations où il faut s’arrêter et la
-méthode de récupération.
+Suivez le guide [Reprogrammer et configurer un répéteur](../meshcore/flash-repeater.md).
 
 ## Choisir les bons paramètres radio et régionaux
 
@@ -105,3 +92,16 @@ Consultez les conseils sur les [antennes](../hardware/recommended-antenna.md) et
 les [méthodes de fixation](../hardware/repeater-mounting-options.md) avant
 l’installation finale. Si une vérification échoue,
 [obtenez de l’aide](get-help.md).
+
+<section class="mc-start-progress" data-mc-progress-page="repeater" aria-labelledby="repeater-progress-title">
+  <h2 id="repeater-progress-title">Liste de vérification</h2>
+  <p>Cette liste est enregistrée uniquement dans ce navigateur.</p>
+  <ol>
+    <li><label><input id="repeater-progress-hardware" type="checkbox" data-mc-progress> Confirmer que le matériel et l’emplacement conviennent</label></li>
+    <li><label><input id="repeater-progress-prepare" type="checkbox" data-mc-progress> Sauvegarder les données et préparer l’appareil</label></li>
+    <li><label><input id="repeater-progress-flash" type="checkbox" data-mc-progress> Suivre le guide d’installation du micrologiciel</label></li>
+    <li><label><input id="repeater-progress-configure" type="checkbox" data-mc-progress> Appliquer les paramètres locaux et régionaux</label></li>
+    <li><label><input id="repeater-progress-verify-local" type="checkbox" data-mc-progress> Vérifier le répéteur sur l’établi</label></li>
+    <li><label><input id="repeater-progress-verify-community" type="checkbox" data-mc-progress> Faire un essai avec un compagnon à proximité</label></li>
+  </ol>
+</section>

--- a/docs/start/repeater.md
+++ b/docs/start/repeater.md
@@ -21,7 +21,7 @@ requires:
 page_styles:
   - assets/styles/repeater-hash-check.css?v=20260820-1
 page_scripts:
-  - assets/javascripts/repeater-hash-check.js?v=20260820-1
+  - assets/javascripts/repeater-hash-check.js?v=20260904-1
 ---
 
 # Start with a repeater
@@ -29,6 +29,8 @@ page_scripts:
 A repeater extends coverage by routing traffic for other users. Because it is
 fixed infrastructure, plan its power, antenna, access, and maintenance before
 installation.
+
+[Install and configure a repeater](../meshcore/flash-repeater.md){ .md-button .md-button--primary }
 
 ## Before you start
 
@@ -42,24 +44,10 @@ installation.
 The guide installs repeater firmware and sets radio, identity, adverts, and
 regional settings. Test on the bench before a difficult installation.
 
-<section class="mc-start-progress" data-mc-progress-page="repeater" aria-labelledby="repeater-progress-title">
-  <h2 id="repeater-progress-title">Setup checklist</h2>
-  <p>Checks are saved only in this browser.</p>
-  <ol>
-    <li><label><input id="repeater-progress-hardware" type="checkbox" data-mc-progress> Confirm compatible hardware and site</label></li>
-    <li><label><input id="repeater-progress-prepare" type="checkbox" data-mc-progress> Back up and prepare</label></li>
-    <li><label><input id="repeater-progress-flash" type="checkbox" data-mc-progress> Follow the flashing guide</label></li>
-    <li><label><input id="repeater-progress-configure" type="checkbox" data-mc-progress> Apply local and regional settings</label></li>
-    <li><label><input id="repeater-progress-verify-local" type="checkbox" data-mc-progress> Bench-check the repeater</label></li>
-    <li><label><input id="repeater-progress-verify-community" type="checkbox" data-mc-progress> Test with a nearby companion</label></li>
-  </ol>
-</section>
 
 ## Flash the repeater
 
-Follow [Flash and configure a repeater](../meshcore/flash-repeater.md). Use the
-board-specific decisions, backup guidance, stop conditions, and recovery path
-in that guide.
+Follow [Flash and configure a repeater](../meshcore/flash-repeater.md).
 
 ## Use the right radio and region settings
 
@@ -87,6 +75,19 @@ The repeater is ready to install when:
 3. a nearby known-good companion receives that advert.
 
 Use the [repeater verification checklist](verify.md#repeater).
+
+<section class="mc-start-progress" data-mc-progress-page="repeater" aria-labelledby="repeater-progress-title">
+  <h2 id="repeater-progress-title">Setup checklist</h2>
+  <p>Checks are saved only in this browser.</p>
+  <ol>
+    <li><label><input id="repeater-progress-hardware" type="checkbox" data-mc-progress> Confirm compatible hardware and site</label></li>
+    <li><label><input id="repeater-progress-prepare" type="checkbox" data-mc-progress> Back up and prepare</label></li>
+    <li><label><input id="repeater-progress-flash" type="checkbox" data-mc-progress> Follow the flashing guide</label></li>
+    <li><label><input id="repeater-progress-configure" type="checkbox" data-mc-progress> Apply local and regional settings</label></li>
+    <li><label><input id="repeater-progress-verify-local" type="checkbox" data-mc-progress> Bench-check the repeater</label></li>
+    <li><label><input id="repeater-progress-verify-community" type="checkbox" data-mc-progress> Test with a nearby companion</label></li>
+  </ol>
+</section>
 
 ## What's next
 

--- a/docs/start/room-server.fr.md
+++ b/docs/start/room-server.fr.md
@@ -25,6 +25,8 @@ Un serveur de salon garde un salon partagé accessible. Il ne remplace pas un
 répéteur : utilisez un répéteur pour acheminer le trafic et améliorer la
 couverture.
 
+[Installer et configurer un serveur de salon](../meshcore/flash-room-server.md){ .md-button .md-button--primary }
+
 ## Avant de commencer
 
 - Confirmez que l’outil de reprogrammation offre le micrologiciel
@@ -40,18 +42,7 @@ couverture.
 Le guide lié remplace le micrologiciel et configure l’identité du serveur de
 salon, les identifiants d’accès et les paramètres radio.
 
-<section class="mc-start-progress" data-mc-progress-page="room-server" aria-labelledby="room-server-progress-title">
-  <h2 id="room-server-progress-title">Liste de configuration</h2>
-  <p>Cette liste est enregistrée uniquement dans ce navigateur.</p>
-  <ol>
-    <li><label><input id="room-server-progress-hardware" type="checkbox" data-mc-progress> Confirmer que le matériel est compatible</label></li>
-    <li><label><input id="room-server-progress-prepare" type="checkbox" data-mc-progress> Sauvegarder les données et préparer l’appareil</label></li>
-    <li><label><input id="room-server-progress-flash" type="checkbox" data-mc-progress> Suivre le guide d’installation du micrologiciel</label></li>
-    <li><label><input id="room-server-progress-configure" type="checkbox" data-mc-progress> Appliquer les paramètres d’accès et les paramètres locaux</label></li>
-    <li><label><input id="room-server-progress-verify-local" type="checkbox" data-mc-progress> Vérifier le serveur de salon à proximité</label></li>
-    <li><label><input id="room-server-progress-verify-community" type="checkbox" data-mc-progress> Tester la découverte et l’accès des invités</label></li>
-  </ol>
-</section>
+
 
 ## Installer le micrologiciel du serveur de salon
 
@@ -89,3 +80,16 @@ membre de la communauté à proximité de faire un essai avec un deuxième
 compagnon. Revérifiez la découverte et l’accès des invités après tout
 changement de micrologiciel, d’identifiants ou de paramètres radio. En cas
 d’échec, [obtenez de l’aide](get-help.md).
+
+<section class="mc-start-progress" data-mc-progress-page="room-server" aria-labelledby="room-server-progress-title">
+  <h2 id="room-server-progress-title">Liste de vérification</h2>
+  <p>Cette liste est enregistrée uniquement dans ce navigateur.</p>
+  <ol>
+    <li><label><input id="room-server-progress-hardware" type="checkbox" data-mc-progress> Confirmer que le matériel est compatible</label></li>
+    <li><label><input id="room-server-progress-prepare" type="checkbox" data-mc-progress> Sauvegarder les données et préparer l’appareil</label></li>
+    <li><label><input id="room-server-progress-flash" type="checkbox" data-mc-progress> Suivre le guide d’installation du micrologiciel</label></li>
+    <li><label><input id="room-server-progress-configure" type="checkbox" data-mc-progress> Appliquer les paramètres d’accès et les paramètres locaux</label></li>
+    <li><label><input id="room-server-progress-verify-local" type="checkbox" data-mc-progress> Vérifier le serveur de salon à proximité</label></li>
+    <li><label><input id="room-server-progress-verify-community" type="checkbox" data-mc-progress> Tester la découverte et l’accès des invités</label></li>
+  </ol>
+</section>

--- a/docs/start/room-server.md
+++ b/docs/start/room-server.md
@@ -24,6 +24,8 @@ requires:
 A room server keeps a shared room available. It does not replace a repeater;
 use a repeater for routing and coverage.
 
+[Install and configure a room server](../meshcore/flash-room-server.md){ .md-button .md-button--primary }
+
 ## Before you start
 
 - Confirm the flasher offers room-server firmware for the device.
@@ -36,18 +38,7 @@ use a repeater for routing and coverage.
 The linked guide replaces the firmware and sets room-server identity, access
 credentials, and radio settings.
 
-<section class="mc-start-progress" data-mc-progress-page="room-server" aria-labelledby="room-server-progress-title">
-  <h2 id="room-server-progress-title">Setup checklist</h2>
-  <p>Checks are saved only in this browser.</p>
-  <ol>
-    <li><label><input id="room-server-progress-hardware" type="checkbox" data-mc-progress> Confirm compatible hardware</label></li>
-    <li><label><input id="room-server-progress-prepare" type="checkbox" data-mc-progress> Back up and prepare</label></li>
-    <li><label><input id="room-server-progress-flash" type="checkbox" data-mc-progress> Follow the flashing guide</label></li>
-    <li><label><input id="room-server-progress-configure" type="checkbox" data-mc-progress> Apply access and local settings</label></li>
-    <li><label><input id="room-server-progress-verify-local" type="checkbox" data-mc-progress> Check the room server nearby</label></li>
-    <li><label><input id="room-server-progress-verify-community" type="checkbox" data-mc-progress> Test discovery and guest access</label></li>
-  </ol>
-</section>
+
 
 ## Flash the room server
 
@@ -75,6 +66,19 @@ The room server is ready when:
 3. the administrator can still recover and maintain it.
 
 Use the [room-server verification checklist](verify.md#room-server).
+
+<section class="mc-start-progress" data-mc-progress-page="room-server" aria-labelledby="room-server-progress-title">
+  <h2 id="room-server-progress-title">Setup checklist</h2>
+  <p>Checks are saved only in this browser.</p>
+  <ol>
+    <li><label><input id="room-server-progress-hardware" type="checkbox" data-mc-progress> Confirm compatible hardware</label></li>
+    <li><label><input id="room-server-progress-prepare" type="checkbox" data-mc-progress> Back up and prepare</label></li>
+    <li><label><input id="room-server-progress-flash" type="checkbox" data-mc-progress> Follow the flashing guide</label></li>
+    <li><label><input id="room-server-progress-configure" type="checkbox" data-mc-progress> Apply access and local settings</label></li>
+    <li><label><input id="room-server-progress-verify-local" type="checkbox" data-mc-progress> Check the room server nearby</label></li>
+    <li><label><input id="room-server-progress-verify-community" type="checkbox" data-mc-progress> Test discovery and guest access</label></li>
+  </ol>
+</section>
 
 ## What's next
 

--- a/docs/submit-idea.fr.md
+++ b/docs/submit-idea.fr.md
@@ -16,7 +16,7 @@ estimated_time: 3-5 minutes
 page_styles:
   - stylesheets/extra.css?v=20260722-2
 page_scripts:
-  - javascripts/submission-form.js?v=20260722-2
+  - javascripts/submission-form.js?v=20260904-1
 hide:
   - toc
 ---
@@ -54,13 +54,33 @@ hide:
 
   <div class="submission-form__header">
     <h2>Décrivez votre idée</h2>
-    <p>Remplissez les cinq champs obligatoires.</p>
+    <p>Ajoutez un titre et décrivez le problème ou l’idée. Le reste est facultatif.</p>
   </div>
 
+  <div class="submission-field">
+    <label for="submission-summary">Titre court</label>
+    <input id="submission-summary" name="summary" type="text" maxlength="100" autocomplete="off" placeholder="Exemple : Ajouter une liste de vérification pour les répéteurs" required>
+  </div>
+
+  <div class="submission-form__grid submission-form__grid--ideas">
+    <div class="submission-field">
+      <label for="submission-need">Problème ou idée</label>
+      <textarea id="submission-need" name="need" maxlength="2000" rows="5" placeholder="Expliquez-nous ce qui vous a bloqué." required></textarea>
+    </div>
+
+    <div class="submission-field">
+      <label for="submission-idea">Changement proposé (facultatif)</label>
+      <textarea id="submission-idea" name="idea" maxlength="2000" rows="5" placeholder="Indiquez le changement qui vous aiderait le plus."></textarea>
+    </div>
+  </div>
+
+  <details class="submission-optional">
+    <summary>Ajouter des précisions <span>Facultatif</span></summary>
+    <div class="submission-optional__body">
   <div class="submission-form__grid">
     <div class="submission-field">
       <label for="submission-category">Type d’idée</label>
-      <select id="submission-category" name="category" required>
+      <select id="submission-category" name="category">
         <option value="">Choisissez la meilleure option</option>
         <option value="Newcomer or accessibility improvement">Amélioration pour les personnes qui débutent ou en matière d’accessibilité</option>
         <option value="Documentation correction">Correction de la documentation</option>
@@ -74,7 +94,7 @@ hide:
 
     <div class="submission-field">
       <label for="submission-experience">Votre expérience avec MeshCore</label>
-      <select id="submission-experience" name="experience" required>
+      <select id="submission-experience" name="experience">
         <option value="">Choisissez une option</option>
         <option value="Brand new / researching">Je découvre MeshCore ou je me renseigne</option>
         <option value="Setting up my first node">Je configure mon premier nœud</option>
@@ -85,26 +105,7 @@ hide:
     </div>
   </div>
 
-  <div class="submission-field">
-    <label for="submission-summary">Titre court</label>
-    <input id="submission-summary" name="summary" type="text" maxlength="100" autocomplete="off" placeholder="Exemple : Ajouter une liste de vérification pour les répéteurs" required>
-  </div>
 
-  <div class="submission-form__grid submission-form__grid--ideas">
-    <div class="submission-field">
-      <label for="submission-need">Qu’est-ce qui est difficile en ce moment?</label>
-      <textarea id="submission-need" name="need" maxlength="2000" rows="5" placeholder="Expliquez-nous ce qui vous a bloqué." required></textarea>
-    </div>
-
-    <div class="submission-field">
-      <label for="submission-idea">Qu’est-ce qui devrait être amélioré?</label>
-      <textarea id="submission-idea" name="idea" maxlength="2000" rows="5" placeholder="Indiquez le changement qui vous aiderait le plus." required></textarea>
-    </div>
-  </div>
-
-  <details class="submission-optional">
-    <summary>Ajouter des précisions <span>Facultatif</span></summary>
-    <div class="submission-optional__body">
       <div class="submission-form__grid">
         <div class="submission-field">
           <label for="submission-region">Ville ou grande région</label>

--- a/docs/submit-idea.md
+++ b/docs/submit-idea.md
@@ -16,7 +16,7 @@ estimated_time: 3-5 minutes
 page_styles:
   - stylesheets/extra.css?v=20260722-2
 page_scripts:
-  - javascripts/submission-form.js?v=20260722-2
+  - javascripts/submission-form.js?v=20260904-1
 hide:
   - toc
 ---
@@ -54,13 +54,33 @@ hide:
 
   <div class="submission-form__header">
     <h2>Describe your idea</h2>
-    <p>Fill five required fields.</p>
+    <p>Add a title and describe the problem or idea. Everything else is optional.</p>
   </div>
 
+  <div class="submission-field">
+    <label for="submission-summary">Short title</label>
+    <input id="submission-summary" name="summary" type="text" maxlength="100" autocomplete="off" placeholder="Example: Add a repeater checklist" required>
+  </div>
+
+  <div class="submission-form__grid submission-form__grid--ideas">
+    <div class="submission-field">
+      <label for="submission-need">Problem or idea</label>
+      <textarea id="submission-need" name="need" maxlength="2000" rows="5" placeholder="Tell us what blocked you." required></textarea>
+    </div>
+
+    <div class="submission-field">
+      <label for="submission-idea">Suggested change (optional)</label>
+      <textarea id="submission-idea" name="idea" maxlength="2000" rows="5" placeholder="Tell us the one change that would help."></textarea>
+    </div>
+  </div>
+
+  <details class="submission-optional">
+    <summary>Add context <span>Optional</span></summary>
+    <div class="submission-optional__body">
   <div class="submission-form__grid">
     <div class="submission-field">
       <label for="submission-category">Type of idea</label>
-      <select id="submission-category" name="category" required>
+      <select id="submission-category" name="category">
         <option value="">Choose the best match</option>
         <option>Newcomer or accessibility improvement</option>
         <option>Documentation correction</option>
@@ -74,7 +94,7 @@ hide:
 
     <div class="submission-field">
       <label for="submission-experience">Your MeshCore experience</label>
-      <select id="submission-experience" name="experience" required>
+      <select id="submission-experience" name="experience">
         <option value="">Choose one</option>
         <option>Brand new / researching</option>
         <option>Setting up my first node</option>
@@ -85,26 +105,7 @@ hide:
     </div>
   </div>
 
-  <div class="submission-field">
-    <label for="submission-summary">Short title</label>
-    <input id="submission-summary" name="summary" type="text" maxlength="100" autocomplete="off" placeholder="Example: Add a repeater checklist" required>
-  </div>
 
-  <div class="submission-form__grid submission-form__grid--ideas">
-    <div class="submission-field">
-      <label for="submission-need">What is hard right now?</label>
-      <textarea id="submission-need" name="need" maxlength="2000" rows="5" placeholder="Tell us what blocked you." required></textarea>
-    </div>
-
-    <div class="submission-field">
-      <label for="submission-idea">What should improve?</label>
-      <textarea id="submission-idea" name="idea" maxlength="2000" rows="5" placeholder="Tell us the one change that would help." required></textarea>
-    </div>
-  </div>
-
-  <details class="submission-optional">
-    <summary>Add context <span>Optional</span></summary>
-    <div class="submission-optional__body">
       <div class="submission-form__grid">
         <div class="submission-field">
           <label for="submission-region">City or broad region</label>

--- a/maintenance/site-audit-2026-09-04.md
+++ b/maintenance/site-audit-2026-09-04.md
@@ -24,7 +24,7 @@ problems without changing region boundaries, broker accounts, or deployment targ
 | A14 — Flashing | Erase and DFU steps are conditional; bootloader verification refers to the selected release, not a contradictory fixed version. | Content safety tests; no hardware was flashed. |
 | A15 — Hardware wording | Removed an unverified antenna-length claim; distinguished shopping-basket costs from per-device cost; shortened French and maintenance prose. | Content review; experimental-build warnings remain. |
 | A16 — Broker reference | Broker table is generated into HTML and works without JavaScript. Access inventory and existing admins remain linked. | Static-table and no-JavaScript browser tests. |
-| A17 — Contributor/testing gaps | Added a contributor README, safety regressions, and mobile map/editor performance coverage. The interactive map loads automatically when visible, keeping its large display layer out of text-only lookups. | Existing quality workflow with downloadable Lighthouse reports; budgets are unchanged. |
+| A17 — Contributor/testing gaps | Added a contributor README, safety regressions, and mobile map/editor performance coverage. The map and region table load when visible. Tiles appear before the boundary overlay, and 17 inline icons replace the full icon-library download. Page scripts no longer block the initial render. | Quality workflow with downloadable Lighthouse reports; budgets and throttling profiles are unchanged. The audit server uses HTTP gzip, matching the live GitHub Pages responses. |
 
 The wording pass is targeted, not a claim that every sentence needed rewriting.
 Existing URLs, community contributions, downloadable build files, and unresolved

--- a/maintenance/site-audit-2026-09-04.md
+++ b/maintenance/site-audit-2026-09-04.md
@@ -1,0 +1,63 @@
+# September 2026 site audit follow-up
+
+This change follows the full English/French site audit against main
+`c7569011b2a52546282ca034f0ff678b95cfba64`. It fixes the configuration and usability
+problems without changing region boundaries, broker accounts, or deployment targets.
+
+## Changes by audit finding
+
+| Finding | Implemented change | Verification |
+|---|---|---|
+| A01 — Radio defaults | Configurator and observer commands preserve current radio/hash settings. Explicit Canada and BC Mesh profiles come from the community source. | Profile unit tests and bilingual command-generation journeys. |
+| A02 — Broker slots | Helpers reuse Canada slots or choose free slots; unrelated connections survive. No-room failures leave the file untouched. Backups are unique. | Bash/PowerShell empty, one-line, occupied, existing, full, rerun, and restore fixtures. |
+| A03 — Map handoff | Location, shared/extra paths, firmware, and radio choices reach configuration. Invalid saved locations offer recovery. | Bilingual map-to-config tests. |
+| A04 — Language state | Map/config language links preserve supported selections, not arbitrary query fields. | Language-switch journey and source-page validation. |
+| A05 — Ambiguous searches | Partial registry matches no longer block city lookup; genuine ambiguous matches offer selectable results. | Québec geocoder fixture and Victoria choices. |
+| A06 — Observer role | Repeating defaults off and is separate from observing. Existing MQTT slots 3–6 are no longer cleared. | Command-builder tests and bilingual role/glossary review. |
+| A07 — Region clarity | Shorter labels distinguish routing regions from coverage and radio networks; results link to communities. | Result/handoff journeys and source review. |
+| A08 — Accessible tools | Theme-aware map surfaces and focus colours; province browsing is collapsible. | Light/dark focused-control contrast checks and desktop/mobile page sweep. |
+| A09 — Fewer setup detours | Direct setup buttons precede checklists; unrelated automatic next-role links are removed. First-message steps precede app tracing. | Setup/content tests and existing route/anchor checks. |
+| A10 — Language | Shorter EN/FR setup and maintenance wording; corrected observer definitions and byte labels. | Bilingual content checks and runtime journeys. |
+| A11 — Region standard | Operator quick start precedes technical rules; draft status and incomplete network adoption are explicit. | Content/anchor checks; no authority edits. |
+| A12 — Directory | Update links carry the exact community and page. Labels separate listing review from link checks. All 24 listings remain. | Generated-data validation and feedback-prefill tests. |
+| A13 — Feedback | Title, description, and public acknowledgement are sufficient. Source-page context survives preview and submission. | Client/server schema tests, simulated submissions, older-gateway fallback. |
+| A14 — Flashing | Erase and DFU steps are conditional; bootloader verification refers to the selected release, not a contradictory fixed version. | Content safety tests; no hardware was flashed. |
+| A15 — Hardware wording | Removed an unverified antenna-length claim; distinguished shopping-basket costs from per-device cost; shortened French and maintenance prose. | Content review; experimental-build warnings remain. |
+| A16 — Broker reference | Broker table is generated into HTML and works without JavaScript. Access inventory and existing admins remain linked. | Static-table and no-JavaScript browser tests. |
+| A17 — Contributor/testing gaps | Added a contributor README, safety regressions, and map/editor performance coverage including mobile. | Existing quality workflow; budgets are unchanged. |
+
+The wording pass is targeted, not a claim that every sentence needed rewriting.
+Existing URLs, community contributions, downloadable build files, and unresolved
+safety warnings are retained.
+
+## Required rollout order
+
+The anonymous submission gateway deploys separately from the static site.
+Deploy its backward-compatible change first and verify that `/config` reports
+`communityIdeaOptionalDetails: true`; then publish the site. See the
+[gateway runbook](../tools/region-proposal-gateway/README.md#short-form-rollout-order).
+An older gateway cannot accept the shorter payload, so the site offers copy/GitHub
+fallbacks instead of attempting a failing anonymous submission. The boundary-editor
+contract is unchanged. No deployment is part of this PR.
+
+## Human confirmations still needed
+
+- **Regional maintainers:** formal adoption of the registry and the decision on
+  boundary proposal #63. Published data is not evidence of network-wide adoption.
+- **Community contacts:** current local radio profiles, overlap between communities,
+  missing contact/language details, and the scope of earlier verification dates.
+  No new verification dates or associations are invented here.
+- **Build contributors:** exact hardware revisions, schematics, safe readings,
+  climate limits, and reproduction evidence for the unfinished solar guides.
+  The 1 W guide remains experimental; software checks do not certify hardware.
+- **Infrastructure operators:** subscriber authentication details and retention/
+  deletion policy. This PR does not change credentials or promise a retention period.
+
+## Review checklist
+
+- Inspect explicit Canada/BC Mesh commands and keep-current defaults.
+- Check the map → configuration → French journey on a phone and desktop.
+- Review short-form feedback in both languages, including the originating page.
+- Confirm the gateway rollout prerequisite before merging for publication.
+- Read the actual quality-workflow result for this PR; this document describes
+  coverage and does not substitute for a passing run.

--- a/maintenance/site-audit-2026-09-04.md
+++ b/maintenance/site-audit-2026-09-04.md
@@ -15,7 +15,7 @@ problems without changing region boundaries, broker accounts, or deployment targ
 | A05 — Ambiguous searches | Partial registry matches no longer block city lookup; genuine ambiguous matches offer selectable results. | Québec geocoder fixture and Victoria choices. |
 | A06 — Observer role | Repeating defaults off and is separate from observing. Existing MQTT slots 3–6 are no longer cleared. | Command-builder tests and bilingual role/glossary review. |
 | A07 — Region clarity | Shorter labels distinguish routing regions from coverage and radio networks; results link to communities. | Result/handoff journeys and source review. |
-| A08 — Accessible tools | Theme-aware map surfaces and focus colours; province browsing is collapsible. | Light/dark focused-control contrast checks and desktop/mobile page sweep. |
+| A08 — Accessible tools | Theme-aware map surfaces and focus colours; province browsing is collapsible. Map controls no longer need a nested scrollbar, and the keyboard skip link cannot overlap buttons. | Light/dark focused-control contrast checks and desktop/mobile page sweep. |
 | A09 — Fewer setup detours | Direct setup buttons precede checklists; unrelated automatic next-role links are removed. First-message steps precede app tracing. | Setup/content tests and existing route/anchor checks. |
 | A10 — Language | Shorter EN/FR setup and maintenance wording; corrected observer definitions and byte labels. | Bilingual content checks and runtime journeys. |
 | A11 — Region standard | Operator quick start precedes technical rules; draft status and incomplete network adoption are explicit. | Content/anchor checks; no authority edits. |
@@ -24,7 +24,7 @@ problems without changing region boundaries, broker accounts, or deployment targ
 | A14 — Flashing | Erase and DFU steps are conditional; bootloader verification refers to the selected release, not a contradictory fixed version. | Content safety tests; no hardware was flashed. |
 | A15 — Hardware wording | Removed an unverified antenna-length claim; distinguished shopping-basket costs from per-device cost; shortened French and maintenance prose. | Content review; experimental-build warnings remain. |
 | A16 — Broker reference | Broker table is generated into HTML and works without JavaScript. Access inventory and existing admins remain linked. | Static-table and no-JavaScript browser tests. |
-| A17 — Contributor/testing gaps | Added a contributor README, safety regressions, and map/editor performance coverage including mobile. | Existing quality workflow; budgets are unchanged. |
+| A17 — Contributor/testing gaps | Added a contributor README, safety regressions, and mobile map/editor performance coverage. The interactive map loads automatically when visible, keeping its large display layer out of text-only lookups. | Existing quality workflow with downloadable Lighthouse reports; budgets are unchanged. |
 
 The wording pass is targeted, not a claim that every sentence needed rewriting.
 Existing URLs, community contributions, downloadable build files, and unresolved

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,7 +34,6 @@ theme:
     - navigation.tabs.sticky
     - navigation.sections
     - navigation.path
-    - navigation.footer
     - navigation.top
     - search.suggest
     - search.highlight

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -39,7 +39,7 @@
   {{ super() }}
   {% if page and page.meta %}
     {% for script in page.meta.page_scripts or [] %}
-      <script src="{{ script | url }}"></script>
+      <script src="{{ script | url }}" defer></script>
     {% endfor %}
     {% for module in page.meta.page_modules or [] %}
       <script type="module" src="{{ module | url }}"></script>

--- a/overrides/partials/page-feedback.html
+++ b/overrides/partials/page-feedback.html
@@ -2,11 +2,11 @@
   {% set page_locale = i18n_page_locale | default(config.theme.language, true) %}
   <aside class="mc-page-feedback" aria-label="{% if page_locale == 'fr' %}Commentaires sur la page{% else %}Page feedback{% endif %}">
     {% if page_locale == "fr" %}
-      <p>Cette première version française vous semble-t-elle claire et naturelle?</p>
-      <a class="md-button" href="{{ 'fr/submit-idea/' | url }}">Signaler une amélioration</a>
+      <p>Cette page vous a-t-elle été utile?</p>
+      <a class="md-button" href="{{ 'fr/submit-idea/' | url }}?source_page={{ ('https://meshcore.ca/' ~ page.url) | urlencode }}">Signaler une amélioration</a>
     {% else %}
       <p>Was this page useful?</p>
-      <a class="md-button" href="{{ 'submit-idea/' | url }}">Suggest a change</a>
+      <a class="md-button" href="{{ 'submit-idea/' | url }}?source_page={{ ('https://meshcore.ca/' ~ page.url) | urlencode }}">Suggest a change</a>
     {% endif %}
   </aside>
 {% endif %}

--- a/scripts/add-meshcore-ca-broker.sh
+++ b/scripts/add-meshcore-ca-broker.sh
@@ -30,8 +30,9 @@ Supported installs:
   - Companion radio via meshcore-packet-capture (.env.local)
 
 Usage:
-  MESHCORE_CA_IATA=YOW bash <(curl -fsSL https://live.meshcore.ca/scripts/add-meshcore-ca-broker.sh)
-  bash <(curl -fsSL https://live.meshcore.ca/scripts/add-meshcore-ca-broker.sh) --iata YOW --device serial-host
+  curl -fsSLo add-meshcore-ca-broker.sh https://meshcore.ca/analyzer/scripts/add-meshcore-ca-broker.sh
+  less add-meshcore-ca-broker.sh
+  bash ./add-meshcore-ca-broker.sh --iata YOW --device serial-host
 
 Options:
   --iata CODE             Real 3-letter IATA airport code.
@@ -531,15 +532,28 @@ set_packetcapture_slot() {
   upsert_env "$file" "PACKETCAPTURE_MQTT${slot}_TOPIC_PACKETS" 'meshcore/{IATA}/{PUBLIC_KEY}/packets'
 }
 
-disable_packetcapture_slot() {
-  local file="$1"
-  local slot="$2"
-  upsert_env "$file" "PACKETCAPTURE_MQTT${slot}_ENABLED" "false"
-  upsert_env "$file" "PACKETCAPTURE_MQTT${slot}_SERVER" ""
+choose_packetcapture_slots() {
+  local file="$1" n server slot1="" slot2="" free=()
+  for n in 1 2 3 4 5 6; do
+    server="$(env_value "$file" "PACKETCAPTURE_MQTT${n}_SERVER" | tr -d '\r')"
+    server="${server#\"}"; server="${server%\"}"
+    server="${server#\'}"; server="${server%\'}"
+    if [ "$server" = "$BROKER1_HOST" ] && [ -z "$slot1" ]; then slot1="$n"
+    elif [ "$server" = "$BROKER2_HOST" ] && [ -z "$slot2" ]; then slot2="$n"
+    elif [ -z "$server" ]; then free+=("$n")
+    fi
+  done
+  if [ -z "$slot1" ] && [ "${#free[@]}" -gt 0 ]; then slot1="${free[0]}"; free=("${free[@]:1}"); fi
+  if [ -z "$slot2" ] && [ "${#free[@]}" -gt 0 ]; then slot2="${free[0]}"; fi
+  if [ -z "$slot1" ] || [ -z "$slot2" ]; then
+    echo "Not enough empty broker slots. Keep your existing connections, or free two slots and run again. No settings changed." >&2
+    return 1
+  fi
+  printf '%s %s\n' "$slot1" "$slot2"
 }
 
 patch_env_capture() {
-  local env_file current_iata backup n
+  local env_file current_iata backup slots slot1 slot2
   env_file="$(packetcapture_env_path)"
   install_packetcapture
   mkdir -p "$(dirname "$env_file")"
@@ -550,16 +564,15 @@ patch_env_capture() {
   fi
   require_iata
 
+  slots="$(choose_packetcapture_slots "$env_file")" || return 1
+  read -r slot1 slot2 <<< "$slots"
   backup="$(backup_path "$env_file")"
   cp -p "$env_file" "$backup"
   chmod 0600 "$backup"
 
   upsert_env "$env_file" "PACKETCAPTURE_IATA" "$IATA"
-  set_packetcapture_slot "$env_file" 1 "$BROKER1_HOST"
-  set_packetcapture_slot "$env_file" 2 "$BROKER2_HOST"
-  for n in 3 4 5 6; do
-    disable_packetcapture_slot "$env_file" "$n"
-  done
+  set_packetcapture_slot "$env_file" "$slot1" "$BROKER1_HOST"
+  set_packetcapture_slot "$env_file" "$slot2" "$BROKER2_HOST"
   chmod 0600 "$env_file"
   say "Patched: $env_file"
   say "Backup written: $backup"

--- a/scripts/postprocess-site.mjs
+++ b/scripts/postprocess-site.mjs
@@ -210,6 +210,20 @@ function fallbackUrl(siteRoot, file, siteBaseUrl) {
   return new URL(route, siteBaseUrl).href;
 }
 
+export function brokerReferenceRows(config, french = false) {
+  const escape = (value) => String(value).replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll('"', "&quot;");
+  if (config.schema_version !== 1 || config.brokers?.length !== 2 || !config.brokers.every((broker) =>
+    /^mqtt[12]\.meshcore\.ca$/.test(broker.host) && broker.port === 443 && broker.tls === true &&
+    broker.verify_tls === true && broker.transport === "websockets" && broker.token_audience === broker.host)) {
+    throw new Error("Invalid observer broker configuration");
+  }
+  return config.brokers.map((broker) => "<tr>" + [
+    broker.id === "primary" ? (french ? "Principal" : "Primary") : (french ? "Secours" : "Backup"),
+    broker.host, broker.port, "WebSockets", french ? "Requis; vérifier les certificats" : "Required; verify certificates",
+    broker.token_audience,
+  ].map((value) => `<td>${escape(value)}</td>`).join("") + "</tr>").join("\n");
+}
+
 async function hashArtifact(siteRoot) {
   const files = (await walk(siteRoot))
     .map((file) => ({
@@ -273,6 +287,11 @@ export async function postprocessSite(siteDirectory, options = {}) {
     let html = await readFile(file, "utf8");
     const originalHtml = html;
     const pageName = relative(siteRoot, file).split(sep).join("/");
+    if (html.includes('<tbody id="broker-reference-body"></tbody>')) {
+      const config = JSON.parse(await readFile(join(siteRoot, "analyzer/observer-config.json"), "utf8"));
+      html = html.replace('<tbody id="broker-reference-body"></tbody>',
+        `<tbody id="broker-reference-body">${brokerReferenceRows(config, pageName.startsWith("fr/"))}</tbody>`);
+    }
     html = rewriteAlternateLinks(html, siteBaseUrl, pageName);
     if (options.noIndexAll) html = ensureNoIndex(html, file);
     if (html !== originalHtml) await writeFile(file, html, "utf8");

--- a/scripts/run-lighthouse.mjs
+++ b/scripts/run-lighthouse.mjs
@@ -36,7 +36,7 @@ function startServer() {
   const command = process.platform === "win32" ? "python.exe" : "python3";
   return spawn(
     command,
-    ["-m", "http.server", "4174", "--bind", "127.0.0.1", "--directory", ".tmp/site"],
+    ["scripts/serve-audit-site.py", "--port", "4174", "--directory", ".tmp/site"],
     { stdio: "ignore", windowsHide: true }
   );
 }

--- a/scripts/run-lighthouse.mjs
+++ b/scripts/run-lighthouse.mjs
@@ -2,7 +2,7 @@ import { spawn } from "node:child_process";
 import { mkdir, writeFile } from "node:fs/promises";
 import process from "node:process";
 import { launch } from "chrome-launcher";
-import lighthouse, { desktopConfig } from "lighthouse";
+import lighthouse, { desktopConfig, defaultConfig } from "lighthouse";
 import { normalizeSiteBaseUrl, resolveSiteRoute } from "../tests/browser/site-route.mjs";
 
 const suppliedBaseUrl = process.env.LIGHTHOUSE_BASE_URL;
@@ -14,7 +14,12 @@ const routes = [
   ["config", "/config/"],
   ["submit-idea", "/submit-idea/"],
   ["fr-home", "/fr/"],
-  ["fr-config", "/fr/config/"]
+  ["fr-config", "/fr/config/"],
+  ["map-result", "/config/map/?tag=ott"],
+  ["editor", "/config/editor/"],
+  ["mobile-map-result", "/config/map/?tag=ott", "mobile"],
+  ["mobile-fr-map-result", "/fr/config/map/?tag=ott", "mobile"],
+  ["mobile-editor", "/config/editor/", "mobile"]
 ];
 const budgets = {
   performance: 0.8,
@@ -81,7 +86,7 @@ async function run() {
   if (!warmup) throw new Error(`Lighthouse warm-up returned no result for ${warmupUrl}`);
 
   const failures = [];
-  for (const [name, route] of routes) {
+  for (const [name, route, device] of routes) {
     const url = resolveSiteRoute(baseUrl, route);
     const html = await (await fetch(url)).text();
     const intentionallyNoIndex = hasNoIndex(html);
@@ -90,7 +95,7 @@ async function run() {
       output: "json",
       logLevel: "error",
       onlyCategories: Object.keys(budgets)
-    }, desktopConfig);
+    }, device === "mobile" ? defaultConfig : desktopConfig);
     if (!result) throw new Error(`Lighthouse returned no result for ${url}`);
 
     await writeFile(

--- a/scripts/serve-audit-site.py
+++ b/scripts/serve-audit-site.py
@@ -1,0 +1,59 @@
+"""Local-only Lighthouse server with the HTTP gzip used by GitHub Pages."""
+
+import argparse
+import gzip
+import io
+from functools import partial
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from urllib.parse import urlsplit
+
+
+def accepts_gzip(header):
+    for item in header.lower().split(","):
+        name, *options = (part.strip() for part in item.split(";"))
+        if name != "gzip":
+            continue
+        for option in options:
+            if option.startswith("q="):
+                try:
+                    return float(option[2:]) > 0
+                except ValueError:
+                    return False
+        return True
+    return False
+
+
+class AuditHandler(SimpleHTTPRequestHandler):
+    def send_head(self):
+        path = Path(self.translate_path(self.path))
+        if path.is_dir() and urlsplit(self.path).path.endswith("/"):
+            path = path / "index.html"
+        compressible = path.suffix.lower() in {
+            ".html", ".css", ".js", ".json", ".geojson", ".svg", ".xml", ".txt"
+        }
+        if not (compressible and path.is_file() and accepts_gzip(self.headers.get("Accept-Encoding", ""))):
+            return super().send_head()
+        try:
+            payload = gzip.compress(path.read_bytes(), compresslevel=6, mtime=0)
+        except OSError:
+            return super().send_head()
+        self.send_response(200)
+        self.send_header("Content-Type", self.guess_type(str(path)))
+        self.send_header("Content-Encoding", "gzip")
+        self.send_header("Vary", "Accept-Encoding")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        return io.BytesIO(payload)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--directory", default=".tmp/site", type=Path)
+    parser.add_argument("--port", default=4174, type=int)
+    args = parser.parse_args()
+    if not args.directory.is_dir():
+        parser.error("Build the site before starting the audit server.")
+    handler = partial(AuditHandler, directory=str(args.directory.resolve()))
+    with ThreadingHTTPServer(("127.0.0.1", args.port), handler) as server:
+        server.serve_forever()

--- a/scripts/validate-communities.py
+++ b/scripts/validate-communities.py
@@ -13,7 +13,7 @@ from collections import Counter
 from datetime import date
 from pathlib import Path
 from typing import Any
-from urllib.parse import urlparse
+from urllib.parse import urlparse, quote
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -590,8 +590,8 @@ def contact_check_label(contacts: list[dict[str, Any]]) -> str:
     if health == {"verified"}:
         checked_dates = {contact["last_checked"] for contact in contacts}
         if len(checked_dates) == 1:
-            return f"Verified on {checked_dates.pop()}"
-        return "All links verified"
+            return f"Links checked on {checked_dates.pop()}"
+        return "All links checked"
     if "verified" in health:
         return "Some links still need review"
     return "Not yet verified"
@@ -648,7 +648,7 @@ def render_directory_card(community: dict[str, Any], page: dict[str, Any]) -> st
             f'{html.escape(page["title"].title())}</a></p>'
         ),
         f"<p><strong>Settings:</strong> {render_settings(community, compact=True)}</p>",
-        f"<p><strong>Last verified:</strong> {verification_label(community)}</p>",
+        f"<p><strong>Listing reviewed:</strong> {verification_label(community)}</p>",
         '<ul class="mc-community-contacts">',
         *render_contacts(community),
         "</ul>",
@@ -826,7 +826,7 @@ def render_community_card(community: dict[str, Any], metadata: dict[str, Any]) -
         "<dl class=\"mc-community-facts\">",
         "<div><dt>Settings</dt>",
         f"<dd>{render_settings(community)}</dd></div>",
-        "<div><dt>Last verified</dt>",
+        "<div><dt>Listing reviewed</dt>",
         f"<dd>{verification_label(community)}</dd></div>",
         "</dl>",
         ]
@@ -876,7 +876,7 @@ def render_community_card(community: dict[str, Any], metadata: dict[str, Any]) -
     lines.extend(
         [
             (
-                '<p class="mc-community-card__action"><a href="../../submit-idea/">'
+                f'<p class="mc-community-card__action"><a href="../../submit-idea/?community={community["id"]}&amp;source_page={quote("https://meshcore.ca" + community["canonical_route"], safe="")}">'
                 "Update this listing</a></p>"
             ),
             "</article>",
@@ -1155,7 +1155,7 @@ def contact_check_label_fr(contacts: list[dict[str, Any]]) -> str:
         checked_dates = {contact["last_checked"] for contact in contacts}
         if len(checked_dates) == 1:
             return f"Effectuée le {checked_dates.pop()}"
-        return "Tous les liens sont vérifiés"
+        return "Tous les liens ont été vérifiés"
     if "verified" in health:
         return "Certains liens restent à vérifier"
     return "Pas encore effectuée"
@@ -1219,7 +1219,7 @@ def render_directory_card_fr(
                 f'{html.escape(page_translation["title"])}</a></p>'
             ),
             f"<p><strong>Réglages :</strong> {render_settings_fr(community, compact=True)}</p>",
-            f"<p><strong>Dernière vérification :</strong> {verification_label_fr(community)}</p>",
+            f"<p><strong>Fiche révisée :</strong> {verification_label_fr(community)}</p>",
             '<ul class="mc-community-contacts">',
             *render_contacts_fr(community),
             "</ul>",
@@ -1435,7 +1435,7 @@ def render_community_card_fr(
             '<dl class="mc-community-facts">',
             "<div><dt>Réglages</dt>",
             f"<dd>{render_settings_fr(community)}</dd></div>",
-            "<div><dt>Dernière vérification</dt>",
+            "<div><dt>Fiche révisée</dt>",
             f"<dd>{verification_label_fr(community)}</dd></div>",
             "</dl>",
         ]
@@ -1491,7 +1491,7 @@ def render_community_card_fr(
     lines.extend(
         [
             (
-                '<p class="mc-community-card__action"><a href="../../submit-idea/">'
+                f'<p class="mc-community-card__action"><a href="../../submit-idea/?community={community["id"]}&amp;source_page={quote("https://meshcore.ca/fr" + community["canonical_route"], safe="")}">'
                 "Mettre cette fiche à jour</a></p>"
             ),
             "</article>",
@@ -1645,6 +1645,16 @@ def render_province_page_fr(
 
 def generated_pages(data: dict[str, Any], french: dict[str, Any]) -> dict[Path, str]:
     pages = {PROVINCES_DIR / "index.md": render_index(data)}
+    profiles = [{"id": "canada", "name": "Canada default", "name_fr": "Réglages canadiens par défaut",
+                 "radio": data["national_defaults"]["raw_radio"], "route": "provinces/#canada-baseline"}]
+    for community in data["communities"]:
+        radio = community["settings"]["overrides"].get("raw_radio")
+        if radio and community.get("verified_at"):
+            profiles.append({"id": community["id"], "name": community["name"],
+                             "name_fr": community["name"], "radio": radio,
+                             "route": community["canonical_route"].lstrip("/"),
+                             "reviewed": community["verified_at"]})
+    pages[ROOT / "docs/assets/radio-profiles.json"] = json.dumps(profiles, ensure_ascii=False, indent=2)
     for page in data["directory_pages"]:
         pages[PROVINCES_DIR / f"{page['slug']}.md"] = render_province_page(data, page)
     pages[PROVINCES_DIR / "index.fr.md"] = render_index_fr(data, french)

--- a/tests/browser/audit-regressions.spec.mjs
+++ b/tests/browser/audit-regressions.spec.mjs
@@ -44,6 +44,43 @@ for (const locale of ["", "fr/"]) {
     await expect(page.locator('[data-go-step="4"]')).toBeDisabled();
   });
 
+  test(`${locale || "en/"} map loads when visible and its keyboard shortcut stays out of the way`, async ({ page }, testInfo) => {
+    const displayRequests = [];
+    page.on("request", (request) => {
+      if (request.url().endsWith("/canada-region-partition.geojson")) displayRequests.push(request.url());
+    });
+    await page.route("https://tile.openstreetmap.org/**", (route) => route.fulfill({
+      contentType: "image/png",
+      body: Buffer.from("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=", "base64")
+    }));
+    await page.goto(siteRoute(`/${locale}config/map/?tag=ott`));
+    await expect(page.locator('[data-role="map-status"]')).toHaveText(locale ? "Région trouvée." : "Region found.");
+    const shortcut = page.locator(".mcc-skip-map");
+    await expect(shortcut).toHaveCSS("pointer-events", "none");
+    await expect(page.locator('[data-role="map-region-table"]')).toBeEmpty();
+    const panel = page.locator(".mcc-map-panel");
+    expect(await panel.evaluate((element) => element.scrollHeight <= element.clientHeight + 1)).toBeTruthy();
+    if (testInfo.project.name.startsWith("mobile-")) {
+      await page.evaluate(() => new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve))));
+      expect(displayRequests).toHaveLength(0);
+    }
+    await page.locator(".mcc-map-stage").scrollIntoViewIfNeeded();
+    await expect(page.locator('[data-role="map-loading"]')).toBeHidden();
+    expect(displayRequests).toHaveLength(1);
+    const marker = page.locator(".leaflet-marker-icon");
+    await expect(marker).toBeVisible();
+    await expect(marker).toHaveAttribute("src", /\/vendor\/leaflet\/images\/marker-icon(?:-2x)?\.png$/);
+    await expect.poll(() => marker.evaluate((image) => image.naturalWidth)).toBeGreaterThan(0);
+    await shortcut.focus();
+    await expect(shortcut).toHaveCSS("opacity", "1");
+    await expect(shortcut).toHaveCSS("pointer-events", "auto");
+    const contrast = await new AxeBuilder({ page }).include(".mcc-map-stage").withRules(["color-contrast"]).analyze();
+    expect(contrast.violations).toEqual([]);
+    await shortcut.press("Enter");
+    await expect(page.locator("#mcc-region-list")).toHaveAttribute("open", "");
+    await expect(page.locator('[data-role="table-filter"]')).toBeVisible();
+  });
+
   for (const scheme of ["default", "slate"]) {
     test(`${locale || "en/"} ${scheme} focused map controls remain readable`, async ({ page }) => {
       await page.goto(siteRoute(`/${locale}config/map/?tag=ott`));

--- a/tests/browser/audit-regressions.spec.mjs
+++ b/tests/browser/audit-regressions.spec.mjs
@@ -119,6 +119,46 @@ test("language switch keeps selected region, firmware, radio, and review step", 
   await expect(page.locator("html")).toHaveAttribute("lang", "fr");
 });
 
+test("map tiles appear while a slow boundary overlay is still loading", async ({ page }) => {
+  let releaseBoundary;
+  const boundaryGate = new Promise(resolve => { releaseBoundary = resolve; });
+  await page.route("**/canada-region-partition.geojson", async route => {
+    await boundaryGate;
+    await route.continue();
+  });
+  await page.route("https://tile.openstreetmap.org/**", route => route.fulfill({
+    contentType: "image/png",
+    body: Buffer.from("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=", "base64")
+  }));
+  try {
+    await page.goto(siteRoute("/config/map/?tag=ott"));
+    await page.locator(".mcc-map-stage").scrollIntoViewIfNeeded();
+    await expect(page.locator(".leaflet-tile-loaded").first()).toBeVisible();
+    await expect(page.locator('[data-role="map-loading"]')).toBeHidden();
+    await expect(page.locator('[data-role="map-boundary-status"]')).toBeVisible();
+    releaseBoundary();
+    await expect(page.locator(".mcc-map-stage")).toHaveAttribute("aria-busy", "false");
+    await expect(page.locator('[data-role="map-boundary-status"]')).toBeHidden();
+  } finally { releaseBoundary(); }
+});
+
+test("map retry restores the selected marker after a tile failure", async ({ page }) => {
+  let tilesAvailable = false;
+  await page.route("https://tile.openstreetmap.org/**", route => tilesAvailable ? route.fulfill({
+    contentType: "image/png",
+    body: Buffer.from("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=", "base64")
+  }) : route.abort());
+  await page.goto(siteRoute("/config/map/?tag=ott"));
+  await page.locator(".mcc-map-stage").scrollIntoViewIfNeeded();
+  const retry = page.locator('[data-action="load-map"]');
+  await expect(retry).toBeVisible();
+  tilesAvailable = true;
+  await retry.click();
+  await expect(page.locator(".mcc-map-stage")).toHaveAttribute("aria-busy", "false");
+  await expect(page.locator(".leaflet-marker-icon")).toBeVisible();
+  await expect(page.locator('[data-role="map-text-result"]')).toContainText("Ottawa");
+});
+
 test("Québec partial matches reach city search and true ambiguity offers buttons", async ({ page }) => {
   let lookedUp = false;
   await page.route("https://nominatim.openstreetmap.org/**", async (route) => {

--- a/tests/browser/audit-regressions.spec.mjs
+++ b/tests/browser/audit-regressions.spec.mjs
@@ -1,0 +1,156 @@
+import { expect, test } from "@playwright/test";
+import AxeBuilder from "@axe-core/playwright";
+import { siteRoute } from "./site-route.mjs";
+import { submissionSha256 } from "../../docs/config/editor/issue.js";
+
+for (const locale of ["", "fr/"]) {
+  test(`${locale || "en/"} region setup preserves radio until explicitly selected`, async ({ page }) => {
+    await page.goto(siteRoute(`/${locale}config/?tag=mvrd&step=4`));
+    const result = page.locator('[data-role="result"]');
+    await expect(result).toContainText("region def can bc mvrd");
+    await expect(result).not.toContainText("set radio");
+    await expect(result).not.toContainText("set path.hash.mode");
+    await page.locator('[data-go-step="3"]').click();
+    await page.locator("#mcc-radio-profile").selectOption("bc-mesh");
+    await page.locator("#mcc-hash-mode").selectOption("2");
+    await expect(page.locator('[data-action="view-map"]').first()).toHaveAttribute("href", /radio=bc-mesh&hash=2/);
+    await page.locator('[data-wizard-step="3"] [data-next-step]').click();
+    await expect(result).toContainText("set radio 910.425,62.5,7,5");
+    await expect(result).toContainText("set path.hash.mode 2");
+    await expect(page.locator('[data-role="review-summary"]')).toContainText("910.425");
+    await page.locator('[data-go-step="3"]').click();
+    await page.locator("#mcc-radio-profile").selectOption("canada");
+    await page.locator('[data-wizard-step="3"] [data-next-step]').click();
+    await expect(result).toContainText("set radio 910.525,62.5,7,5");
+  });
+
+  test(`${locale || "en/"} map handoff retains shared and extra region paths`, async ({ page }) => {
+    await page.goto(siteRoute(`/${locale}config/map/?tag=ott&type=large&regions=mtl&firmware=1.15`));
+    const link = page.locator('[data-role="map-text-result"] .mcc-detail-actions a');
+    await expect(link).toBeVisible();
+    await link.click();
+    await expect(page.locator('[data-role="selected-region"]')).toContainText("Ottawa");
+    await page.locator('[data-wizard-step="3"] [data-next-step]').click();
+    const result = page.locator('[data-role="result"]');
+    await expect(result).toContainText("region put ott");
+    await expect(result).toContainText("region put gatout");
+    await expect(result).toContainText("region put mtl");
+    await expect(result).not.toContainText("set radio");
+  });
+
+  test(`${locale || "en/"} invalid saved location offers recovery instead of commands`, async ({ page }) => {
+    await page.goto(siteRoute(`/${locale}config/?tag=unknown&lat=999&lon=0`));
+    await expect(page.locator('[data-role="status"]')).toHaveText(/invalid|invalide/);
+    await expect(page.locator('[data-go-step="4"]')).toBeDisabled();
+  });
+
+  for (const scheme of ["default", "slate"]) {
+    test(`${locale || "en/"} ${scheme} focused map controls remain readable`, async ({ page }) => {
+      await page.goto(siteRoute(`/${locale}config/map/?tag=ott`));
+      await expect(page.locator('[data-role="map-text-result"]')).toContainText("Ottawa");
+      await page.locator(`input[data-md-color-scheme="${scheme}"]`).evaluate((element) => element.click());
+      const find = page.locator('[data-action="map-locate"]');
+      await find.focus();
+      await find.hover();
+      const results = await new AxeBuilder({ page }).include("[data-mcc-regions]").withRules(["color-contrast"]).analyze();
+      expect(results.violations).toEqual([]);
+      const background = await page.locator(".md-main").evaluate((element) => getComputedStyle(element).backgroundColor);
+      expect(background).toBe(scheme === "default" ? "rgb(255, 255, 255)" : "rgb(15, 22, 35)");
+    });
+  }
+
+  test(`${locale || "en/"} broker reference works without JavaScript`, async ({ browser }) => {
+    const context = await browser.newContext({ javaScriptEnabled: false });
+    try {
+      const page = await context.newPage();
+      await page.goto(siteRoute(`/${locale}analyzer/broker-reference/`));
+      await expect(page.locator("#broker-reference-body tr")).toHaveCount(2);
+      await expect(page.locator("#broker-reference-body")).toContainText("mqtt1.meshcore.ca");
+      await expect(page.locator('article a[href*="data-collection-access/#read-only-mqtt-accounts"]')).toBeVisible();
+    } finally { await context.close(); }
+  });
+}
+
+test("language switch keeps selected region, firmware, radio, and review step", async ({ page }) => {
+  await page.goto(siteRoute("/config/?tag=mvrd&step=4&firmware=1.15&radio=bc-mesh&hash=2"));
+  await expect(page.locator('[data-role="result"]')).toContainText("set radio 910.425");
+  await page.locator(".md-select > button").click();
+  await page.locator('.md-select__link[hreflang="fr"]').click();
+  await expect(page.locator('[data-role="result"]')).toContainText("set radio 910.425");
+  await expect(page.locator('[data-role="result"]')).toContainText("region put mvrd bc");
+  await expect(page.locator('[data-wizard-step="4"]')).toBeVisible();
+  await expect(page.locator("html")).toHaveAttribute("lang", "fr");
+});
+
+test("Québec partial matches reach city search and true ambiguity offers buttons", async ({ page }) => {
+  let lookedUp = false;
+  await page.route("https://nominatim.openstreetmap.org/**", async (route) => {
+    lookedUp = true;
+    await route.fulfill({ json: [{ lat: "46.8139", lon: "-71.2080", display_name: "Québec, Québec, Canada", address: { country_code: "ca", state: "Quebec" } }] });
+  });
+  await page.goto(siteRoute("/fr/config/map/"));
+  const input = page.locator('[data-role="map-input"]');
+  await input.fill("Québec");
+  await page.locator('[data-action="map-locate"]').click();
+  await expect(page.locator('[data-role="map-text-result"]')).toContainText("Québec");
+  expect(lookedUp).toBeTruthy();
+  await input.fill("Victoria");
+  await page.locator('[data-action="map-locate"]').click();
+  const choices = page.locator('[data-role="map-status"] button');
+  await expect(choices.first()).toBeVisible();
+  expect(await choices.count()).toBeGreaterThan(1);
+  await choices.first().click();
+  await expect(page.locator('[data-role="map-text-result"]')).toBeVisible();
+});
+
+test("feedback remembers its page and accepts a title and description", async ({ page }) => {
+  await page.goto(siteRoute("/start/repeater/"));
+  await page.locator(".mc-page-feedback a").click();
+  await expect(page.locator('input[name="source_page"]')).toHaveValue("https://meshcore.ca/start/repeater/");
+  await page.locator("#submission-summary").fill("Clarify one instruction");
+  await page.locator("#submission-need").fill("The step needs a clearer example.");
+  await page.locator("#submission-public").check();
+  await page.locator("#review-submission").click();
+  await expect(page.locator("#submission-preview")).toContainText("https://meshcore.ca/start/repeater/");
+  await expect(page.locator("#submission-error-summary")).toBeHidden();
+});
+
+for (const locale of ["", "fr/"]) {
+  for (const modernGateway of [true, false]) {
+    test(`${locale || "en/"} short feedback ${modernGateway ? "submits to a compatible gateway" : "offers a safe older-gateway fallback"}`, async ({ page }) => {
+      let posted = null;
+      await page.addInitScript(() => {
+        window.turnstile = { render(_container, options) { setTimeout(() => options.callback("fixture-token"), 0); return "fixture"; }, reset() {} };
+      });
+      await page.route("https://api.meshcore.ca:21323/api/meshcore-canada/submissions**", async (route) => {
+        const request = route.request();
+        if (request.method() === "GET") return route.fulfill({ json: {
+          version: 1, turnstileSiteKey: "fixture-site-key", turnstileAction: "meshcore_submission",
+          ...(modernGateway ? { communityIdeaOptionalDetails: true } : {})
+        } });
+        posted = request.postDataJSON().submission;
+        return route.fulfill({ json: { ok: true, issueNumber: 123, issueUrl: "https://github.com/MeshCore-ca/MeshCore-Canada/issues/123",
+          submissionSha256: await submissionSha256(posted), duplicate: false } });
+      });
+      await page.goto(siteRoute(`/${locale}start/repeater/`));
+      await page.locator(".mc-page-feedback a").click();
+      await expect(page.locator('input[name="source_page"]')).toHaveValue(`https://meshcore.ca/${locale}start/repeater/`);
+      await page.locator("#submission-summary").fill("Clarify one instruction");
+      await page.locator("#submission-need").fill("The step needs a clearer example.");
+      await page.locator("#submission-public").check();
+      await page.locator("#review-submission").click();
+      if (modernGateway) {
+        await page.locator("#submit-community-idea").click();
+        await expect(page.locator("#submission-result")).toHaveAttribute("data-state", "success");
+        expect(posted.experience).toBe("");
+        expect(posted.idea).toBe("");
+        expect(posted.sourcePage).toBe(`https://meshcore.ca/${locale}start/repeater/`);
+      } else {
+        await expect(page.locator("#submission-anti-spam-status")).toHaveAttribute("data-state", "error");
+        await expect(page.locator("#submit-community-idea")).toBeDisabled();
+        await expect(page.locator("#open-github-submission")).toHaveAttribute("href", /github.com/);
+        expect(posted).toBeNull();
+      }
+    });
+  }
+}

--- a/tests/browser/critical-journeys.spec.mjs
+++ b/tests/browser/critical-journeys.spec.mjs
@@ -244,6 +244,7 @@ test("region map loads OpenStreetMap tiles without a consent gate", async ({ pag
   await page.goto(siteRoute("/config/map/"), { waitUntil: "domcontentloaded" });
   await expect(page.locator("[data-action='tile-consent']")).toHaveCount(0);
   await expect(page.getByText(/Allow OpenStreetMap tiles/i)).toHaveCount(0);
+  await page.locator(".mcc-map-stage").scrollIntoViewIfNeeded();
   await expect(page.locator("[data-role='map-area']")).toBeVisible();
   await expect(page.locator("[data-role='map-loading']")).toBeHidden();
   await expect(page.locator(".leaflet-tile-loaded").first()).toBeVisible();

--- a/tests/content/analyzer-journey.test.mjs
+++ b/tests/content/analyzer-journey.test.mjs
@@ -160,7 +160,7 @@ test("broker reference lists every administrator and public contact in both lang
 
 test("verification distinguishes connectivity from an observed packet", () => {
   const source = read("docs/analyzer/verify.md");
-  assert.match(source, /broker connection proves only/i);
+  assert.match(source, /Connected does not mean packets have reached CoreScope/i);
   assert.match(source, /Follow a packet through four stages/);
   for (const stage of ["Radio:", "Observer:", "Observer view:", "Packet view:"]) {
     assert.match(source, new RegExp(stage));
@@ -236,7 +236,7 @@ test("standalone builder is external, fail-closed, redacted, and non-persistent"
   const script = read("docs/assets/javascripts/analyzer-command-builder.js");
 
   assert.doesNotMatch(page, /<style>|<script>/);
-  assert.match(page, /page_scripts:\n  - assets\/javascripts\/analyzer-command-builder\.js/);
+  assert.match(page, /page_scripts:\n(?:  - [^\n]+\n)*  - assets\/javascripts\/analyzer-command-builder\.js/);
   assert.match(page, /type="password"/);
   assert.doesNotMatch(page.match(/<input id="observer-ssid"[^>]*>/)?.[0] || "", /\svalue=/);
   assert.match(script, /safeCliToken/);
@@ -251,8 +251,9 @@ test("standalone builder is external, fail-closed, redacted, and non-persistent"
 test("review-first host setup precedes remote execution and includes rollback", () => {
   const source = read("docs/analyzer/builds/mctomqtt.md");
   const review = source.indexOf("### 1. Download and inspect the helper");
-  const oneLiner = source.indexOf("bash <(curl -fsSL");
-  assert.ok(review >= 0 && oneLiner > review);
+  const runHelper = source.indexOf("bash add-meshcore-ca-broker.sh");
+  assert.ok(review >= 0 && runHelper > review);
+  assert.doesNotMatch(source, /bash <\(curl/);
   assert.match(source, /not pinned|pinned release checksum/i);
   assert.match(source, /--no-restart.*not a dry run/i);
   assert.match(source, /\.bak\.<timestamp>/);

--- a/tests/content/analyzer-journey.test.mjs
+++ b/tests/content/analyzer-journey.test.mjs
@@ -129,6 +129,8 @@ test("privacy pages state ownership, access, the account inventory, and the unkn
   for (const service of [
     "Beacon (`dev.meshcore.ca`)",
     "CoreScope (`live.meshcore.ca`)",
+    "[Canadaverse](https://canadaverse.org/)",
+    "[n30nex@gmail.com](mailto:n30nex@gmail.com)",
     "[Quinte Mesh](https://quintemesh.ca/)",
   ]) {
     assert.ok(source.includes(service), `English inventory missing ${service}`);
@@ -136,6 +138,8 @@ test("privacy pages state ownership, access, the account inventory, and the unkn
   }
   assert.ok(source.includes("hansimgamr"), "English inventory missing the Quinte Mesh operator");
   assert.ok(french.includes("hansimgamr"), "French inventory missing the Quinte Mesh operator");
+  assert.ok(source.includes("GTA Regional Tools & CartoLive map"), "English inventory missing the Canadaverse purpose");
+  assert.ok(french.includes("Outils régionaux du Grand Toronto et carte CartoLive"), "French inventory missing the Canadaverse purpose");
   assert.match(source, /update this table whenever they create or remove a read-only account/i);
   assert.match(french, /mettre ce tableau à jour chaque\s+fois qu’ils créent ou retirent un compte en lecture seule/i);
 });

--- a/tests/content/broker-helpers.test.mjs
+++ b/tests/content/broker-helpers.test.mjs
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import { copyFileSync, existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+
+const gitPath = spawnSync("git", ["--exec-path"], { encoding: "utf8" }).stdout?.trim();
+const bash = process.platform === "win32" && gitPath ? resolve(gitPath, "../../../bin/bash.exe") : "bash";
+const helpers = [
+  ["Bash", bash, (dir) => [resolve("docs/analyzer/scripts/add-meshcore-ca-broker.sh").replaceAll("\\", "/"),
+    "--device", "companion", "--mode", "env", "--no-restart", "--iata", "YOW", "--dir", dir.replaceAll("\\", "/")]],
+  ["PowerShell", "pwsh", (dir) => ["-NoProfile", "-NonInteractive", "-File", resolve("docs/analyzer/scripts/add-meshcore-ca-packetcapture-broker.ps1"), "-Iata", "YOW", "-InstallDir", dir]],
+];
+const unrelated = (slot) => `PACKETCAPTURE_MQTT${slot}_SERVER=other${slot}.example\nPACKETCAPTURE_MQTT${slot}_ENABLED=false\nPACKETCAPTURE_MQTT${slot}_PASSWORD=fixture-only-${slot}\n`;
+
+for (const [name, executable, args] of helpers) {
+  for (const scenario of ["empty", "one line", "other connections", "existing Canada", "full", "one free slot"]) {
+    test(`${name} preserves broker settings: ${scenario}`, () => {
+      assert.ok(process.platform !== "win32" || name !== "Bash" || existsSync(executable), "Git Bash is required on Windows");
+      const dir = mkdtempSync(join(tmpdir(), "mcc-broker-test-"));
+      const config = join(dir, ".env.local");
+      const initial = scenario === "empty" ? "" : scenario === "one line" ? "UNCHANGED=fixture\n" : scenario === "other connections" ? unrelated(1) + unrelated(3)
+        : scenario === "existing Canada" ? unrelated(1) + "PACKETCAPTURE_MQTT4_SERVER=mqtt1.meshcore.ca\nPACKETCAPTURE_MQTT6_SERVER=mqtt2.meshcore.ca\n"
+        : Array.from({ length: scenario === "full" ? 6 : 5 }, (_, i) => unrelated(i + 1)).join("");
+      try {
+        writeFileSync(config, initial);
+        writeFileSync(join(dir, "packet_capture.py"), "# Install marker; never executed.\n");
+        const run = () => spawnSync(executable, args(dir), { encoding: "utf8", timeout: process.platform === "win32" ? 60000 : 30000 });
+        const first = run();
+        if (["full", "one free slot"].includes(scenario)) {
+          assert.notEqual(first.status, 0);
+          assert.match(first.stderr + first.stdout, /Not enough empty broker slots/);
+          assert.equal(readFileSync(config, "utf8"), initial);
+          assert.equal(readdirSync(dir).filter((file) => file.includes(".bak.")).length, 0);
+          return;
+        }
+        assert.equal(first.status, 0, first.stderr + first.stdout);
+        const output = readFileSync(config, "utf8");
+        for (const line of initial.trim().split("\n").filter(Boolean)) assert.ok(output.includes(line), line);
+        for (const host of ["mqtt1.meshcore.ca", "mqtt2.meshcore.ca"]) {
+          assert.equal(output.split("\n").filter((line) => line.trimEnd().endsWith("_SERVER=" + host)).length, 1);
+        }
+        if (scenario === "existing Canada") assert.match(output, /PACKETCAPTURE_MQTT4_SERVER=mqtt1.meshcore.ca/);
+        const originalBackup = readdirSync(dir).find((file) => file.includes(".bak."));
+        assert.equal(readFileSync(join(dir, originalBackup), "utf8"), initial);
+        const second = run();
+        assert.equal(second.status, 0, second.stderr + second.stdout);
+        assert.equal(readFileSync(config, "utf8"), output, "repeated setup is idempotent");
+        assert.equal(readdirSync(dir).filter((file) => file.includes(".bak.")).length, 2);
+        copyFileSync(join(dir, originalBackup), config);
+        assert.equal(readFileSync(config, "utf8"), initial, "backup restores original configuration");
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+  }
+}

--- a/tests/content/community-directory.test.mjs
+++ b/tests/content/community-directory.test.mjs
@@ -315,7 +315,7 @@ test("all listings inherit the three-byte Canada baseline", () => {
   const quebec = readFileSync(join(provinceDir, "quebec.md"), "utf8");
   assert.match(
     quebec,
-    /<h3>Réseau MESH de Charlevoix \(YML\)<\/h3>[\s\S]*?<strong>Listing contact:<\/strong> pifane[\s\S]*?<strong>Contact check:<\/strong> Verified on 2026-08-29/,
+    /<h3>Réseau MESH de Charlevoix \(YML\)<\/h3>[\s\S]*?<strong>Listing contact:<\/strong> pifane[\s\S]*?<strong>Contact check:<\/strong> Links checked on 2026-08-29/,
   );
   const quebecFr = readFileSync(join(provinceDir, "quebec.fr.md"), "utf8");
   assert.match(

--- a/tests/content/configurator-ui.test.mjs
+++ b/tests/content/configurator-ui.test.mjs
@@ -64,3 +64,19 @@ test("place searches run on submission and visible maps load without consent", (
   assert.match(regionsSource, /tile\.openstreetmap\.org/);
   assert.match(regionsSource, /Browse regions without search or a map/);
 });
+
+test("region icons are inline SVGs matching the vendored source", () => {
+  const names = [...new Set([...regionsSource.matchAll(/icon\("([^"]+)"\)/g)].map(match => match[1]))].sort();
+  const icons = JSON.parse(regionsSource.match(/var ICONS = (\{[\s\S]*?\n  \});/)[1]);
+  assert.deepEqual(Object.keys(icons).sort(), names);
+  const context = vm.createContext({});
+  vm.runInContext(read("docs/assets/regions/vendor/lucide.js"), context);
+  for (const name of names) {
+    const key = name.replace(/(^|-)([a-z])/g, (_, dash, letter) => letter.toUpperCase());
+    const expected = context.lucide.icons[key].map(([tag, attrs]) =>
+      '<' + tag + ' ' + Object.entries(attrs).map(([key, value]) => key + '=' + JSON.stringify(value)).join(' ') + ' />'
+    ).join('');
+    assert.equal(icons[name], expected);
+  }
+  assert.doesNotMatch(regionsSource, /loadLucide|refreshIcons|data-lucide/);
+});

--- a/tests/content/configurator-ui.test.mjs
+++ b/tests/content/configurator-ui.test.mjs
@@ -53,13 +53,14 @@ test("commissioning records omit sensitive and exact location fields", () => {
   assert.doesNotMatch(record, /must-not-appear|45\.4215|-75\.6972/);
 });
 
-test("place searches and map tiles load automatically", () => {
+test("place searches run on submission and visible maps load without consent", () => {
   assert.doesNotMatch(regionsSource, /allowExternal/);
   assert.doesNotMatch(regionsSource, /online-search-consent|map-online-search-consent/);
   assert.match(regionsSource, /setTimeout\(locate, 0\)/);
   assert.match(regionsSource, /geocode\(data, query, thisController && thisController\.signal\)/);
   assert.doesNotMatch(regionsSource, /tile-consent|Allow OpenStreetMap tiles before loading/);
   assert.match(regionsSource, /window\.setTimeout\(loadInteractiveMap, 0\)/);
+  assert.match(regionsSource, /mapObserver\.observe\(els\.mapStage\)/);
   assert.match(regionsSource, /tile\.openstreetmap\.org/);
   assert.match(regionsSource, /Browse regions without search or a map/);
 });

--- a/tests/content/p0-content-safety.test.mjs
+++ b/tests/content/p0-content-safety.test.mjs
@@ -166,6 +166,8 @@ test("observer builder fails closed and redacts valid WiFi credentials", () => {
     ["observer-ssid", new FakeElement()],
     ["observer-password", new FakeElement("", "password")],
     ["observer-repeat", new FakeElement("on")],
+    ["observer-radio", new FakeElement("keep")],
+    ["observer-hash", new FakeElement("keep")],
     ["observer-command-output", new FakeElement()],
     ["observer-copy-status", new FakeElement()],
     ["observer-command-errors", new FakeElement()],
@@ -178,6 +180,7 @@ test("observer builder fails closed and redacts valid WiFi credentials", () => {
     ["observer-location-status", new FakeElement()],
   ]);
   elements.get("observer-board").options = [{ text: "Heltec V3" }];
+  elements.get("observer-hash").options = [{ text: "Keep current settings" }];
   const windowListeners = new Map();
   const fakeWindow = {
     TextEncoder,
@@ -255,11 +258,12 @@ test("observer builder fails closed and redacts valid WiFi credentials", () => {
 test("remote installer guidance explains impact, review, and rollback before one-liners", () => {
   const page = read("docs/analyzer/builds/mctomqtt.md");
   const reviewIndex = page.indexOf("### 1. Download and inspect the helper");
-  const oneLinerIndex = page.indexOf("bash <(curl -fsSL");
+  const oneLinerIndex = page.indexOf("bash add-meshcore-ca-broker.sh");
 
   assert.match(page, /## What this changes/);
   assert.ok(reviewIndex >= 0, "review-first section missing");
-  assert.ok(oneLinerIndex > reviewIndex, "remote one-liner appears before review-first guidance");
+  assert.ok(oneLinerIndex > reviewIndex, "execution appears before review-first guidance");
+  assert.doesNotMatch(page, /bash <\(curl/);
   assert.match(page, /## Recovery/);
   assert.match(page, /not pinned|not versioned/i);
   assert.match(page, /\.bak\.<timestamp>/);

--- a/tests/content/radio-profiles.test.mjs
+++ b/tests/content/radio-profiles.test.mjs
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import vm from "node:vm";
+import test from "node:test";
+
+const source = readFileSync(new URL("../../docs/assets/javascripts/radio-profiles.js", import.meta.url), "utf8");
+const profiles = JSON.parse(readFileSync(new URL("../../docs/assets/radio-profiles.json", import.meta.url), "utf8"));
+
+function fixture({ french = false, offline = false } = {}) {
+  const select = { options: [], notices: [], appendChild(option) { this.options.push(option); }, after(notice) { this.notices.push(notice); } };
+  const window = {};
+  vm.runInNewContext(source, { window, URL, document: {
+    currentScript: { src: "https://meshcore.ca/assets/javascripts/radio-profiles.js" },
+    documentElement: { lang: french ? "fr" : "en" },
+    createElement() { return { setAttribute() {} }; }
+  }, fetch: async () => ({ ok: !offline, json: async () => profiles }) });
+  return { select, api: window.MeshCoreRadioProfiles };
+}
+
+test("radio and hash changes are opt-in and use the shared community source", async () => {
+  const { select, api } = fixture();
+  assert.deepEqual(Array.from(api.commands("keep", "keep")), []);
+  await api.populate(select);
+  assert.equal(select.options.length, profiles.length);
+  assert.deepEqual(Array.from(api.commands("bc-mesh", "2")), ["set radio 910.425,62.5,7,5", "set path.hash.mode 2"]);
+  assert.deepEqual(Array.from(api.commands("canada", "keep")), ["set radio 910.525,62.5,7,5"]);
+  assert.deepEqual(Array.from(api.commands("keep", "0")), ["set path.hash.mode 0"]);
+  assert.throws(() => api.commands("unknown", "2"), /Unknown radio profile/);
+});
+
+test("French labels use the same radio commands", async () => {
+  const { select, api } = fixture({ french: true });
+  await api.populate(select);
+  assert.match(api.label("canada"), /Réglages canadiens/);
+  assert.match(api.label("keep"), /Conserver/);
+  assert.deepEqual(Array.from(api.commands("canada", "1")), ["set radio 910.525,62.5,7,5", "set path.hash.mode 1"]);
+});
+
+test("a failed profile download cannot silently select national radio defaults", async () => {
+  const { select, api } = fixture({ offline: true });
+  await api.populate(select);
+  assert.equal(select.options.length, 0);
+  assert.match(select.notices[0].textContent, /unavailable/);
+  assert.deepEqual(Array.from(api.commands("keep", "keep")), []);
+  assert.throws(() => api.commands("canada", "keep"), /Unknown radio profile/);
+});

--- a/tests/content/site-postprocess.test.mjs
+++ b/tests/content/site-postprocess.test.mjs
@@ -5,7 +5,19 @@ import { tmpdir } from "node:os";
 import test from "node:test";
 import { gunzipSync, gzipSync } from "node:zlib";
 
-import { postprocessSite } from "../../scripts/postprocess-site.mjs";
+import { postprocessSite, brokerReferenceRows } from "../../scripts/postprocess-site.mjs";
+
+test("broker reference is built from the shared validated configuration", async () => {
+  const config = JSON.parse(await readFile(new URL("../../docs/analyzer/observer-config.json", import.meta.url), "utf8"));
+  for (const french of [false, true]) {
+    const rows = brokerReferenceRows(config, french);
+    assert.equal((rows.match(/<tr>/g) || []).length, 2);
+    assert.match(rows, /mqtt1.meshcore.ca/);
+    assert.match(rows, /mqtt2.meshcore.ca/);
+    assert.match(rows, french ? /vérifier les certificats/ : /verify certificates/);
+  }
+  assert.throws(() => brokerReferenceRows({ ...config, brokers: config.brokers.map((broker) => ({ ...broker, tls: false })) }), /Invalid/);
+});
 
 test("noindex pages are removed from the sitemap and recorded in the manifest", async () => {
   const root = await mkdtemp(join(tmpdir(), "mcc-site-postprocess-"));

--- a/tests/content/test_audit_server.py
+++ b/tests/content/test_audit_server.py
@@ -1,0 +1,77 @@
+import gzip
+import http.client
+import importlib.util
+import tempfile
+import threading
+import unittest
+from functools import partial
+from http.server import ThreadingHTTPServer
+from pathlib import Path
+
+
+spec = importlib.util.spec_from_file_location(
+    "audit_server", Path(__file__).resolve().parents[2] / "scripts/serve-audit-site.py"
+)
+audit_server = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(audit_server)
+
+
+class QuietHandler(audit_server.AuditHandler):
+    def log_message(self, *args):
+        pass
+
+
+class AuditServerTests(unittest.TestCase):
+    def setUp(self):
+        self.directory = tempfile.TemporaryDirectory()
+        root = Path(self.directory.name)
+        self.html = "<h1>Régions du Canada</h1>".encode()
+        self.geojson = b'{"type":"FeatureCollection","features":[]}'
+        (root / "index.html").write_bytes(self.html)
+        (root / "region.geojson").write_bytes(self.geojson)
+        self.server = ThreadingHTTPServer(
+            ("127.0.0.1", 0), partial(QuietHandler, directory=str(root))
+        )
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+        self.thread.start()
+
+    def tearDown(self):
+        self.server.shutdown()
+        self.server.server_close()
+        self.thread.join(timeout=5)
+        self.directory.cleanup()
+
+    def request(self, path, encoding="", method="GET"):
+        connection = http.client.HTTPConnection(*self.server.server_address, timeout=5)
+        try:
+            connection.request(method, path, headers={"Accept-Encoding": encoding})
+            response = connection.getresponse()
+            return response.status, dict(response.getheaders()), response.read()
+        finally:
+            connection.close()
+
+    def test_gzip_preserves_html_and_geometry_and_supports_head(self):
+        for path, expected in [("/?tag=ott", self.html), ("/region.geojson", self.geojson)]:
+            with self.subTest(path=path):
+                status, headers, body = self.request(path, "gzip, deflate, br")
+                self.assertEqual(status, 200)
+                self.assertEqual(headers.get("Content-Encoding"), "gzip")
+                self.assertEqual(headers.get("Vary"), "Accept-Encoding")
+                self.assertEqual(gzip.decompress(body), expected)
+                status, head_headers, head_body = self.request(path, "gzip", "HEAD")
+                self.assertEqual(status, 200)
+                self.assertEqual(head_headers.get("Content-Length"), str(len(body)))
+                self.assertEqual(head_body, b"")
+
+    def test_plain_requests_and_missing_files_keep_standard_behavior(self):
+        for encoding in ["", "br", "gzip;q=0", "gzip;q=0.0", "gzip;q=invalid"]:
+            with self.subTest(encoding=encoding):
+                status, headers, body = self.request("/", encoding)
+                self.assertEqual(status, 200)
+                self.assertNotIn("Content-Encoding", headers)
+                self.assertEqual(body, self.html)
+        self.assertEqual(self.request("/missing.html", "gzip")[0], 404)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/content/test_validate_communities.py
+++ b/tests/content/test_validate_communities.py
@@ -20,7 +20,7 @@ def contact(health: str, last_checked: str | None = None) -> dict[str, str | Non
 class ContactCheckLabelTests(unittest.TestCase):
     def test_verified_contact_shows_its_check_date(self) -> None:
         contacts = [contact("verified", "2026-08-08")]
-        self.assertEqual("Verified on 2026-08-08", MODULE.contact_check_label(contacts))
+        self.assertEqual("Links checked on 2026-08-08", MODULE.contact_check_label(contacts))
         self.assertEqual("Effectuée le 2026-08-08", MODULE.contact_check_label_fr(contacts))
 
     def test_unreviewed_contacts_remain_explicit(self) -> None:

--- a/tests/editor/community-submission.test.mjs
+++ b/tests/editor/community-submission.test.mjs
@@ -9,7 +9,8 @@ import {
   COMMUNITY_SUBMISSION_ENDPOINT,
   buildCommunityIdea,
   buildManualGithubLink,
-  buildSubmissionText
+  buildSubmissionText,
+  normalizeSourcePage
 } from "../../docs/javascripts/community-submission.js";
 
 const validData = {
@@ -44,6 +45,22 @@ test("builds the exact canonical community idea contract", () => {
     region: "Waterloo Region, Ontario",
     followUp: "@meshfriend"
   });
+});
+
+test("a short correction needs only a title, description, and public acknowledgement", () => {
+  const proposal = buildCommunityIdea({ summary: "Fix a label", need: "This label is unclear.", publicAcknowledged: true,
+    sourcePage: "https://meshcore.ca/fr/start/repeater/#before-you-start" });
+  assert.equal(proposal.category, "Other community feedback");
+  assert.equal(proposal.experience, "");
+  assert.equal(proposal.idea, "");
+  assert.match(buildSubmissionText(proposal), /Source page[\s\S]*\/fr\/start\/repeater\//);
+  assert.equal(new URL(buildManualGithubLink(proposal).url).searchParams.get("source_page"), proposal.sourcePage);
+});
+
+test("source-page context excludes external URLs, credentials, and private query strings", () => {
+  for (const url of ["https://example.com/", "https://user:password@meshcore.ca/", "https://meshcore.ca/?token=private", "http://meshcore.ca/", "https://meshcore.ca/%3Cscript%3E", "https://meshcore.ca/#<script>"]) {
+    assert.throws(() => normalizeSourcePage(url), /valid source page/);
+  }
 });
 
 test("validates consent, enums, controls, and Unicode before submission", () => {

--- a/tests/editor/issue.test.mjs
+++ b/tests/editor/issue.test.mjs
@@ -32,6 +32,13 @@ const canonicalProposal = {
 };
 
 const canonicalProposalHash = await submissionSha256(canonicalProposal);
+
+test("optional community details require an explicit gateway capability", () => {
+  const config = { version: 1, turnstileSiteKey: "site-key", turnstileAction: "meshcore_submission" };
+  assert.equal(validateSubmissionConfig(config).communityIdeaOptionalDetails, undefined);
+  assert.equal(validateSubmissionConfig({ ...config, communityIdeaOptionalDetails: "true" }).communityIdeaOptionalDetails, undefined);
+  assert.equal(validateSubmissionConfig({ ...config, communityIdeaOptionalDetails: true }).communityIdeaOptionalDetails, true);
+});
 const editorHtml = await readFile(
   new URL("../../docs/config/editor/index.html", import.meta.url),
   "utf8"

--- a/tools/region-proposal-gateway/README.md
+++ b/tools/region-proposal-gateway/README.md
@@ -28,7 +28,7 @@ The base path is `/api/meshcore-canada/submissions`.
 - `GET <base>/config` returns:
 
   ```json
-  {"version":1,"turnstileSiteKey":"...","turnstileAction":"meshcore_submission"}
+  {"version":1,"turnstileSiteKey":"...","turnstileAction":"meshcore_submission","communityIdeaOptionalDetails":true}
   ```
 
 - `POST <base>` accepts exactly:
@@ -62,13 +62,32 @@ newline. It is the idempotency key for both schemas.
 
 The server accepts the fixed category and experience enums plus:
 
-- required `summary`, `need`, `idea`, and `publicAcknowledged: true`;
-- optional `region`, `context`, and `followUp`; and
+- required `summary`, `need`, and `publicAcknowledged: true`;
+- `category` from the existing enum (the form defaults to other feedback);
+- `experience` and `idea` keys, which may now contain empty strings;
+- optional `region`, `context`, `followUp`, and `sourcePage`; and
 - the browser field limits enforced again server-side.
 
 It normalizes line endings, rejects unknown keys, controls and invalid Unicode,
 escapes contributor HTML, and neutralizes GitHub mentions. The issue contains
 human-readable sections and the exact canonical JSON.
+
+`sourcePage` accepts only an HTTPS `meshcore.ca` page with a simple path and
+optional heading anchor. Credentials, query strings, and external sites are rejected.
+Existing complete v1 submissions retain their canonical representation and hash.
+
+### Short-form rollout order
+
+Deploy this backward-compatible gateway update **before** publishing the shorter
+website form. Follow the activation and rollback steps in `instructions.md`, then
+confirm `/config` returns `communityIdeaOptionalDetails: true` with the expected
+CORS headers. Test old and short payloads against a local mocked GitHub service;
+do not create public test issues without approval.
+
+If the older gateway is still serving, the new form keeps its preview, copy, and
+GitHub fallback available but does not attempt an incompatible anonymous POST.
+The region editor does not require this capability and continues to use its
+existing contract. To roll back the gateway, roll back the site form first.
 
 ### `mcc-region-editor-proposal/v1` and `/v2`
 

--- a/tools/region-proposal-gateway/gateway.py
+++ b/tools/region-proposal-gateway/gateway.py
@@ -650,7 +650,7 @@ def validate_idea(raw: object) -> tuple[dict[str, Any], bytes, str]:
         "schema", "category", "experience", "summary", "need", "idea",
         "publicAcknowledged",
     }
-    optional_keys = {"region", "context", "followUp"}
+    optional_keys = {"region", "context", "followUp", "sourcePage"}
     if (
         not isinstance(raw, dict)
         or not required_keys.issubset(raw)
@@ -664,9 +664,9 @@ def validate_idea(raw: object) -> tuple[dict[str, Any], bytes, str]:
         raw.get("category"), 100, required=True, multiline=False
     )
     experience = _clean_idea_text(
-        raw.get("experience"), 100, required=True, multiline=False
+        raw.get("experience"), 100, required=False, multiline=False
     )
-    if category not in IDEA_CATEGORIES or experience not in IDEA_EXPERIENCE_LEVELS:
+    if category not in IDEA_CATEGORIES or (experience and experience not in IDEA_EXPERIENCE_LEVELS):
         raise GatewayError(422, "invalid_submission", "Choose a valid idea category and experience level.")
 
     canonical: dict[str, Any] = {
@@ -675,9 +675,17 @@ def validate_idea(raw: object) -> tuple[dict[str, Any], bytes, str]:
         "experience": experience,
         "summary": _clean_idea_text(raw.get("summary"), 100, required=True, multiline=False),
         "need": _clean_idea_text(raw.get("need"), 2000, required=True, multiline=True),
-        "idea": _clean_idea_text(raw.get("idea"), 2000, required=True, multiline=True),
+        "idea": _clean_idea_text(raw.get("idea"), 2000, required=False, multiline=True),
         "publicAcknowledged": True,
     }
+    if raw.get("sourcePage"):
+        source = _clean_idea_text(raw["sourcePage"], 400, required=False, multiline=False)
+        parsed = urllib.parse.urlsplit(source)
+        if (parsed.scheme != "https" or parsed.netloc != "meshcore.ca" or parsed.query
+                or not re.fullmatch(r"/[a-zA-Z0-9/_.-]*", parsed.path)
+                or not re.fullmatch(r"[a-zA-Z0-9_-]*", parsed.fragment)):
+            raise GatewayError(422, "invalid_submission", "Choose a valid source page.")
+        canonical["sourcePage"] = source
     optional_fields = (
         ("region", 100, False),
         ("context", 2000, True),
@@ -1371,17 +1379,19 @@ def build_idea_issue(
         ),
         f"- Submission SHA-256: `{submission_hash}`",
         f"- Contribution type: **{_safe_markdown_text(canonical['category'])}**",
-        f"- MeshCore experience: **{_safe_markdown_text(canonical['experience'])}**",
+        f"- MeshCore experience: **{_safe_markdown_text(canonical['experience'] or 'Not provided')}**",
     ]
     if canonical.get("region"):
         body_parts.append(
             f"- City or broad region: <span>{_safe_markdown_text(canonical['region'])}</span>"
         )
+    if canonical.get("sourcePage"):
+        body_parts.append(f"- Source page: {_safe_markdown_text(canonical['sourcePage'])}")
     body_parts.extend([
-        "### What are you trying to do, or what is difficult today?",
+        "### Problem or idea",
         _safe_html_block(canonical["need"]),
-        "### What would make it better?",
-        _safe_html_block(canonical["idea"]),
+        "### Suggested change",
+        _safe_html_block(canonical["idea"] or "Not provided"),
     ])
     if canonical.get("context"):
         body_parts.extend([
@@ -1722,7 +1732,7 @@ class GatewayHandler(BaseHTTPRequestHandler):
             return
         self._send(
             200,
-            {"version": API_VERSION, "turnstileSiteKey": self.service.config.turnstile_site_key, "turnstileAction": TURNSTILE_ACTION},
+            {"version": API_VERSION, "turnstileSiteKey": self.service.config.turnstile_site_key, "turnstileAction": TURNSTILE_ACTION, "communityIdeaOptionalDetails": True},
             cors=origin is not None,
         )
 

--- a/tools/region-proposal-gateway/tests/test_gateway.py
+++ b/tools/region-proposal-gateway/tests/test_gateway.py
@@ -341,6 +341,18 @@ class PreviewTests(unittest.TestCase):
 
 
 class IdeaValidationTests(unittest.TestCase):
+    def test_short_feedback_and_source_page(self):
+        idea = valid_idea()
+        idea.update(experience="", idea="", sourcePage="https://meshcore.ca/fr/start/repeater/#before-you-start")
+        canonical, payload, digest = gateway.validate_idea(idea)
+        self.assertEqual(canonical["experience"], "")
+        self.assertEqual(canonical["idea"], "")
+        self.assertEqual(canonical["sourcePage"], idea["sourcePage"])
+        self.assertEqual(digest, hashlib.sha256(payload).hexdigest())
+        for source in ["https://example.com/", "https://user:secret@meshcore.ca/", "https://meshcore.ca/?token=private", "http://meshcore.ca/", "https://meshcore.ca/%3Cscript%3E", "https://meshcore.ca/#<script>"]:
+            with self.subTest(source=source), self.assertRaises(gateway.GatewayError):
+                gateway.validate_idea({**idea, "sourcePage": source})
+
     def test_canonicalizes_optional_fields_and_hash(self):
         canonical, payload, digest = gateway.validate_idea(valid_idea())
         self.assertEqual(canonical["summary"], "Better regional setup help")
@@ -983,7 +995,7 @@ class HttpContractTests(unittest.TestCase):
         status, headers, payload = self.request("GET", gateway.DEFAULT_BASE_PATH + "/config", headers={"Origin": "https://meshcore.ca"})
         self.assertEqual(status, 200)
         self.assertEqual(headers["Access-Control-Allow-Origin"], "https://meshcore.ca")
-        self.assertEqual(payload, {"turnstileAction": gateway.TURNSTILE_ACTION, "turnstileSiteKey": "site-key", "version": 1})
+        self.assertEqual(payload, {"turnstileAction": gateway.TURNSTILE_ACTION, "turnstileSiteKey": "site-key", "version": 1, "communityIdeaOptionalDetails": True})
         status, headers, payload = self.request("GET", gateway.DEFAULT_BASE_PATH + "/config")
         self.assertEqual(status, 200)
         self.assertNotIn("Access-Control-Allow-Origin", headers)


### PR DESCRIPTION
## Summary

Implements the September English/French site audit on top of merged PR #89.

- Preserve local radio settings unless the operator explicitly chooses a profile; include the documented BC Mesh profile.
- Preserve unrelated MQTT connections, reuse existing Canada slots, and fail without changes when both brokers cannot fit.
- Keep location and setup choices through map/configuration and language handoffs; make ambiguous searches actionable.
- Improve light/dark focus contrast and mobile map layout, shorten setup wording, and remove unrelated next-role navigation.
- Load offscreen maps and collapsed tables only when needed; show map tiles before the boundary overlay, and embed the 17 icons used by the tools instead of downloading the full icon library.
- Simplify feedback, preserve its source page, and render the broker reference without JavaScript.
- Clarify conditional erase/DFU instructions, experimental hardware limits, listing review dates, and registry adoption status.
- Add regression tests, contributor instructions, and map/editor performance coverage without lowering budgets.

The [audit follow-up](https://github.com/MeshCore-ca/MeshCore-Canada/blob/codex/site-audit-fixes-20260904/maintenance/site-audit-2026-09-04.md) maps A01–A17 to changes and verification. Existing community listings, restored guides, build downloads, admin contacts, and subscriber inventory are retained. No region boundaries, broker accounts, or credentials are changed. No new dependencies are added.

## Important: gateway before site

The shorter anonymous feedback form needs the gateway update in this PR deployed first. Verify `/config` returns `communityIdeaOptionalDetails: true`, then publish the site. Existing complete v1 submissions and boundary proposals remain compatible. Against an older gateway, the new form offers copy/GitHub fallbacks rather than sending an incompatible request.

See the [rollout instructions](https://github.com/MeshCore-ca/MeshCore-Canada/blob/codex/site-audit-fixes-20260904/tools/region-proposal-gateway/README.md#short-form-rollout-order). This PR does not deploy or merge itself.

## Verification

All three quality jobs passed for **`af65bc6`**: [final workflow run](https://github.com/MeshCore-ca/MeshCore-Canada/actions/runs/33934866205).

- **530 browser tests passed**, with no failures or flaky results; 34 project-specific skips are intentional. Coverage includes all 128 rendered non-404 routes on desktop/mobile and English/French critical journeys across six browser configurations.
- **160 JavaScript tests**, **16 Python content tests**, **47 gateway tests**, and **17 automation tests** passed. Both region-geometry checks passed.
- The strict build and link audit passed for **129 pages and 12,990 local references**. The separate noindex subpath build passed 12,988 link checks and 10 local desktop/mobile setup and language-switch journeys.
- All **12 Lighthouse audits passed**, including the map, bilingual mobile map, and editor. The final map scores were 96 on desktop and 100 on both mobile language routes; accessibility was 99–100 across the audited routes.

The final local map regression pass also completed 24 tests across all six browser configurations, including deferred loading, slow boundaries, retry after tile failure, marker images, and keyboard access. English desktop and French mobile layouts were visually checked.

Tests use temporary broker fixtures and simulated submissions, not live broker changes or public test issues.

The performance server now sends HTTP gzip for text assets, matching the verified live GitHub Pages responses. Performance thresholds and the original simulated mobile/desktop throttling profiles are unchanged. The server is bound to localhost and has compression, identity-response, and HEAD regression tests.

## Still requires human evidence

Formal registry adoption and proposal #63; missing community contact/profile facts; physical reproduction and safe limits for the unfinished solar builds; infrastructure authentication/retention policy. Those are documented explicitly rather than presented as verified by software tests.
