### PR TITLE
Restore the original 1 W solar repeater build guide

### DIFF
--- a/docs/assets/styles/devices-builds.css
+++ b/docs/assets/styles/devices-builds.css
@@ -126,7 +126,7 @@
 .mc-build-table table {
   min-width: 0;
   border-collapse: collapse;
-  font-size: 0.8rem;
+  font-size: 1rem;
   line-height: 1.5;
 }
 

--- a/docs/assets/styles/devices-builds.css
+++ b/docs/assets/styles/devices-builds.css
@@ -123,6 +123,39 @@
   white-space: nowrap;
 }
 
+.mc-build-table table {
+  min-width: 0;
+  border-collapse: collapse;
+  font-size: 0.8rem;
+  line-height: 1.5;
+}
+
+.mc-build-table :is(th, td) {
+  padding: var(--mc-space-3);
+  border-bottom: 1px solid var(--mc-color-border);
+  vertical-align: top;
+}
+
+.mc-build-table th {
+  background: var(--mc-color-surface-raised);
+  text-align: left;
+  white-space: normal;
+}
+
+.mc-parts-table :is(th, td):nth-child(4) {
+  white-space: nowrap;
+}
+
+.mc-build-table .md-typeset__scrollwrap {
+  margin: 0;
+  overflow: visible;
+}
+
+.mc-build-table .md-typeset__table {
+  display: block;
+  padding: 0;
+}
+
 .mc-table-note {
   color: var(--mc-color-text-muted);
   font-size: 0.82rem;
@@ -185,6 +218,12 @@
   max-width: min(100%, 34rem);
   height: auto;
   margin: var(--mc-space-4) auto;
+}
+
+.mc-build-diagram {
+  padding: var(--mc-space-3);
+  border-radius: var(--mc-radius-sm);
+  background: #fff;
 }
 
 @media screen and (max-width: 44.9844em) {

--- a/docs/hardware/index.fr.md
+++ b/docs/hardware/index.fr.md
@@ -62,10 +62,10 @@ ou de commencer les travaux.
     <p>Un modèle RAK à l’état d’ébauche pour les personnes expérimentées, avec une liste de pièces, des étapes d’assemblage, des vérifications sur l’établi et des notes d’entretien.</p>
     <a class="md-button" href="repeater-solar-300mw-diy-build/">Examiner le modèle de 300 mW</a>
   </section>
-  <section class="mc-decision-card" data-status="experimental">
-    <h3>Répéteur solaire expérimental de 1 W</h3>
-    <p>Un modèle haute puissance non vérifié proposé par MrAlders0n. Utilisez-le seulement après qu’un examen électrique, RF et du site a confirmé un besoin réel du réseau.</p>
-    <a class="md-button" href="repeater-solar-1w-diy-build/">Examiner le modèle expérimental de 1 W</a>
+  <section class="mc-decision-card" data-status="draft">
+    <h3>Répéteur solaire de 1 W — Ikoka Stick</h3>
+    <p>Le guide de MrAlders0n, avec pièces, photos, câblage et télémétrie INA3221 facultative.</p>
+    <a class="md-button" href="repeater-solar-1w-diy-build/">Lire le guide de construction de 1 W</a>
   </section>
 </div>
 

--- a/docs/hardware/index.md
+++ b/docs/hardware/index.md
@@ -59,10 +59,10 @@ buying parts or starting work.
     <p>A draft RAK-based build for experienced builders, with a parts list, assembly stages, bench checks, and maintenance notes.</p>
     <a class="md-button" href="repeater-solar-300mw-diy-build/">Review the 300 mW build</a>
   </section>
-  <section class="mc-decision-card" data-status="experimental">
-    <h3>Experimental 1 W solar repeater</h3>
-    <p>An unverified high-power design contributed by MrAlders0n. Use it only after electrical, RF, and site review confirms a real network need.</p>
-    <a class="md-button" href="repeater-solar-1w-diy-build/">Review the experimental 1 W build</a>
+  <section class="mc-decision-card" data-status="draft">
+    <h3>1 W solar repeater — Ikoka Stick</h3>
+    <p>MrAlders0n’s build guide, with parts, assembly photos, wiring, and optional INA3221 telemetry.</p>
+    <a class="md-button" href="repeater-solar-1w-diy-build/">Read the 1 W build guide</a>
   </section>
 </div>
 

--- a/docs/hardware/recommended-repeaters.fr.md
+++ b/docs/hardware/recommended-repeaters.fr.md
@@ -79,10 +79,10 @@ accessoire sélectionné dans la documentation actuelle du fabricant.
     <p>Un modèle RAK à l’état d’ébauche avec une liste de pièces, des étapes d’assemblage, des vérifications sur l’établi et des notes d’entretien.</p>
     <a class="md-button" href="../repeater-solar-300mw-diy-build/">Examiner le modèle de 300 mW</a>
   </section>
-  <section class="mc-decision-card" data-status="experimental">
-    <h3>Répéteur solaire expérimental de 1 W</h3>
-    <p>Un modèle haute puissance non vérifié destiné à un besoin mesuré du réseau. Un examen électrique, RF et du site est requis avant d’acheter des pièces ou de commencer les travaux.</p>
-    <a class="md-button" href="../repeater-solar-1w-diy-build/">Examiner le modèle expérimental de 1 W</a>
+  <section class="mc-decision-card" data-status="draft">
+    <h3>Répéteur solaire de 1 W — Ikoka Stick</h3>
+    <p>Le guide de MrAlders0n, avec pièces, photos, câblage et télémétrie INA3221 facultative.</p>
+    <a class="md-button" href="../repeater-solar-1w-diy-build/">Lire le guide de construction de 1 W</a>
   </section>
 </div>
 

--- a/docs/hardware/recommended-repeaters.md
+++ b/docs/hardware/recommended-repeaters.md
@@ -74,10 +74,10 @@ The SenseCAP Solar Node P1 is one packaged enclosure to evaluate. It is not a co
     <p>A draft RAK-based build with a parts list, assembly stages, bench checks, and maintenance notes.</p>
     <a class="md-button" href="../repeater-solar-300mw-diy-build/">Review the 300 mW build</a>
   </section>
-  <section class="mc-decision-card" data-status="experimental">
-    <h3>Experimental 1 W solar repeater</h3>
-    <p>An unverified high-power design for a measured network need. It requires electrical, RF, and site review before anyone buys parts or starts work.</p>
-    <a class="md-button" href="../repeater-solar-1w-diy-build/">Review the experimental 1 W build</a>
+  <section class="mc-decision-card" data-status="draft">
+    <h3>1 W solar repeater — Ikoka Stick</h3>
+    <p>MrAlders0n’s build guide, with parts, assembly photos, wiring, and optional INA3221 telemetry.</p>
+    <a class="md-button" href="../repeater-solar-1w-diy-build/">Read the 1 W build guide</a>
   </section>
 </div>
 

--- a/docs/hardware/repeater-solar-1w-diy-build.fr.md
+++ b/docs/hardware/repeater-solar-1w-diy-build.fr.md
@@ -1,262 +1,302 @@
 ---
-title: Répéteur solaire expérimental de 1 W
-description: Évaluez un modèle de répéteur solaire haute puissance non vérifié avant de décider de le reproduire.
+title: Construire un répéteur solaire de 1 W avec l’Ikoka Stick
+description: Pièces, prix, photos d’assemblage, schéma de câblage et télémétrie INA3221 facultative pour le répéteur solaire Ikoka Stick de MrAlders0n.
 audience:
   - advanced-repeater-builder
-  - hardware-reviewer
-task: review-1w-solar-repeater-build
-scope: experimental
-status: experimental
+task: build-1w-solar-repeater
+scope: ottawa-field-practice
+status: draft
 status_notice: false
 owner: docs-hardware
-last_reviewed: 2026-07-22
+last_reviewed: 2026-09-09
 review_by: 2026-10-17
 difficulty: advanced
-estimated_time: multiple days including fabrication and cure time
-destructive: false
+estimated_time: plusieurs jours, y compris la fabrication et le durcissement de la colle
+destructive: true
 requires:
   - multimeter
   - soldering-experience
   - fabrication-experience
   - manufacturer-documentation
 page_styles:
-  - assets/styles/devices-builds.css?v=20260728-1
+  - assets/styles/devices-builds.css?v=20260909-1
 ---
 
-# Répéteur solaire expérimental de 1 W
+<span id="repeteur-solaire-experimental-de-1-w"></span>
 
-Ce modèle non vérifié combine une Ikoka Stick 0.4.0, un gestionnaire
-d’alimentation solaire, un parcours RF filtré et un boîtier fabriqué sur mesure.
+# Construire un répéteur solaire de 1 W — Ikoka Stick
 
-<div class="mc-guide-status" data-status="experimental" markdown>
+Par **MrAlders0n (Ottawa)** · Guide d’origine : **1er janvier 2026**
 
-**Ne construisez et ne déployez pas ce modèle sans examen électrique, RF et du
-site.** Sa cible de micrologiciel, sa conception électrique, la télémétrie
-facultative, ses mesures et ses limites climatiques n’ont pas été reproduites.
+Construisez un répéteur MeshCore solaire avec une GOME Ikoka Stick, une boîte de jonction et un panneau solaire collé à l’époxy.
 
-</div>
-
-<dl class="mc-guide-facts">
-  <div><dt>Radio</dt><dd>GOME Ikoka Stick 0.4.0</dd></div>
-  <div><dt>Alimentation</dt><dd>Waveshare Solar Power Manager</dd></div>
-  <div><dt>Micrologiciel</dt><dd>Version non confirmée; fonctionnement non vérifié</dd></div>
-  <div><dt>Entretien</dt><dd>À définir pendant l’examen du site</dd></div>
-</dl>
-
-## Cette construction convient-elle?
-
-Il s’agit d’une expérience spécialisée de dorsale ou de longue portée, et non
-d’une mise à niveau par défaut. Coordonnez-vous avec les communautés voisines
-et démontrez le besoin du site avant de modifier la couverture ou les habitudes
-de trafic.
-
-Utilisez le [modèle de 300 mW à l’état d’ébauche](repeater-solar-300mw-diy-build.md)
-ou un système préassemblé examiné, sauf si une personne responsable du réseau
-et une personne qualifiée en électronique et en RF conviennent que
-cette expérience répond à un besoin mesuré.
+**Carte :** GOME Ikoka Stick (matériel v0.4.0)<br>
+**Alimentation :** Waveshare Solar Power Manager (modèle standard)<br>
+**Micrologiciel :** MeshCore
 
 ## Avant de commencer
 
-!!! danger "Cette construction réunit des RF haute puissance, des piles au lithium, de la recharge, du soudage, de la coupe et une installation extérieure surélevée"
-    Vérifiez chaque composant et chaque limite dans la documentation actuelle du fabricant. Branchez une antenne et un parcours RF examiné avant tout essai de transmission. Ne mettez pas sous tension une pile ou un chargeur lorsque la polarité, la protection, le câblage, la température ou les valeurs attendues sont inconnus.
+!!! warning "Sans garantie"
+    Ce guide communautaire est fourni sans garantie. Vérifiez la continuité et la polarité au multimètre avant de mettre le circuit sous tension. Débranchez le panneau solaire, la batterie et l’USB avant de souder ou de modifier le câblage.
 
-<ul class="mc-checklist">
-  <li>Le besoin du réseau local et les effets sur les autres régions sont documentés.</li>
-  <li>Le matériel Ikoka exact et la cible du micrologiciel du répéteur sont confirmés et récupérables par USB.</li>
-  <li>Une personne qualifiée en électronique approuve la pile, le chargeur, le panneau, le câblage, la protection, la télémétrie facultative et le plan thermique du boîtier.</li>
-  <li>Une personne qualifiée en RF approuve la radio, le filtre, la ligne de transmission RF, l’antenne, les connecteurs et le site.</li>
-  <li>Un examen de la structure et du site couvre la masse finale, la surface du panneau, le montage, le vent, la glace, la neige, le passage des câbles et l’accès.</li>
-  <li>La construction restera sous surveillance sur l’établi jusqu’à l’approbation de son dossier d’essai.</li>
-</ul>
+<span id="cette-construction-convient-elle"></span>
 
-## Ce que cette construction change
+!!! info "Quand utiliser un répéteur de 1 W"
+    Un répéteur de 1 W peut servir aux liaisons principales ou aux endroits où la connexion au maillage est difficile. Il n’est pas nécessaire partout; consultez votre communauté locale.
 
-La procédure découpe et perce un boîtier, colle un panneau solaire avec de
-l’époxy et du scellant, modifie le système de montage, branche un parcours RF
-haute puissance et un filtre, assemble un système d’alimentation au lithium et
-peut retirer les broches de l’écran pour la télémétrie facultative. Plusieurs
-changements sont difficiles ou impossibles à annuler sans remplacer des pièces.
+!!! danger "Antenne obligatoire"
+    **Branchez une antenne LoRa avant d’alimenter l’Ikoka Stick. Émettre sans antenne peut endommager définitivement la radio.** Utilisez le [réglage de puissance MeshCore adapté à votre module Ikoka](https://github.com/meshcore-dev/MeshCore/blob/main/docs/faq.md#77-q-i-have-a-station-g2-or-a-heltec-v4-or-an-ikoka-stick-or-a-radio-with-an-ebyte-e22-900m30s-or-an-ebyte-e22-900m33s-module-what-should-their-transmit-power-be-set-to); une sortie de 1 W ne signifie pas qu’il faut régler la puissance TX à 30 dBm.
 
-## Liste du matériel à vérifier
+<span id="liste-du-materiel-a-verifier"></span>
 
-<div class="mc-table-wrap" markdown>
+## Liste des pièces { #parts-list }
 
-| Nº | Pièce | Qté | Détail à vérifier | Source |
+Les prix proviennent du guide d’origine daté du **1er janvier 2026**. Ce ne sont pas des devis actuels. Les montants sont en dollars canadiens; vérifiez la disponibilité, la livraison et les taxes avant de commander.
+
+<div class="mc-table-wrap mc-build-table mc-parts-table" markdown>
+
+| Nº | Pièce | Qté | Prix | Source |
 |---:|---|---:|---|---|
-| 1 | GOME Ikoka Stick 0.4.0 | 1 | Révision du matériel, bande canadienne, sortie RF, cible du micrologiciel, récupération | [Page du projet](https://github.com/ndoo/ikoka-stick-meshtastic-device) |
-| 2 | Waveshare Solar Power Manager | 1 | Modèle exact, limites du panneau, de la pile et de la sortie, comportement au démarrage, température | [Waveshare](https://www.waveshare.com/wiki/Solar_Power_Manager) |
-| 3 | Boîte de jonction IP65, 220×170×110 mm | 1 | Matériau, indice de protection après modification, température, évent | [AliExpress](https://www.aliexpress.com/item/1005007587120013.html) |
-| 4 | Panneau de 10 W / 18 V, 250×340 mm | 1 | Limites électriques, dimensions, masse, résistance aux intempéries et aux charges | [Amazon](https://a.co/d/0eJo5GCr) |
-| 5 | Bloc 18650 3P1S ou 4P1S | 1 | Chimie, cellules appariées, protection, construction, chargeur, température | [MP&W Supply](https://mpandw.ca/) |
-| 6 | Carte de protection de pile | 1 | Seuils, courant, température, câblage, compatibilité | [Space Hedgehog](https://space-hedgehog.com/products/battery-protection-with-low-voltage-cut-off) |
-| 7 | Filtre passe-bande à quatre cavités de 890–960 MHz, 50 W | 1 | Réponse à 902–928 MHz, perte d’insertion, connecteurs, intempéries, température | [Alibaba](https://www.alibaba.com/product-detail/50W-890-960MHz-4-Cavity-Filter_1601399651944.html) |
-| 8 | Câble de 10–15 cm, SMA à angle droit vers traversée femelle de type N | 1 | Genre et polarité des connecteurs, perte, courbure, joint | [AliExpress](https://www.aliexpress.com/item/1005008569444661.html) |
-| 9 | Câble SMA mâle à angle droit de 7.5 cm | 1 | Correspondance du connecteur, perte, courbure, puissance admissible | [AliExpress](https://www.aliexpress.com/item/1005006702037541.html) |
-| 10 | Câble USB-A vers USB-C à angle droit de 0.5 pi | 1 | Besoins en données et en alimentation, courant, ajustement, tension mécanique | [Amazon](https://a.co/d/045htrEG) |
-| 11–12 | Entretoises M3×35 et vis M3×5 | selon les besoins | Matériau, résistance, ajustement, corrosion | Source locale |
-| 13 | Gorilla Epoxy, 25 ml | 1 | Compatibilité des matériaux, durcissement, limites extérieures et de température | [Home Depot](https://www.homedepot.ca/product/gorilla-epoxy-syringe-25ml/1000778451) |
-| 14 | Bouchon d’évent étanche | 1 | Filetage, circulation d’air, protection contre l’infiltration après l’installation | [AliExpress](https://www.aliexpress.com/item/1005006370919409.html) |
-| 15 | Scellant de silicone extérieur transparent | 1 | Compatibilité des matériaux, durcissement, limites UV et de température | Quincaillerie locale |
-| 16 | Adafruit INA3221, facultatif | 1 | Interface électrique, adresse, prise en charge du micrologiciel, isolation, étalonnage | [DigiKey](https://www.digikey.ca/en/products/detail/adafruit-industries-llc/6062/25660599) |
+| 1 | GOME Ikoka Stick (matériel v0.4.0) | 1 | 55 $ | [GitHub](https://github.com/ndoo/ikoka-stick-meshtastic-device) (achat groupé) |
+| 2 | Waveshare Solar Power Manager (modèle standard) | 1 | 15 $ | [Waveshare](https://www.waveshare.com/wiki/Solar_Power_Manager) |
+| 3 | Boîte de jonction IP65 grise, 220 × 170 × 110 mm | 1 | 30 $ | [AliExpress](https://www.aliexpress.com/item/1005007587120013.html) |
+| 4 | Panneau solaire de 10 W / 18 V, 250 × 340 mm | 1 | 35 $ | [Amazon](https://a.co/d/0eJo5GCr) |
+| 5 | Bloc de batteries 18650 en 3P1S (ou 4P1S) | 1 | 25–35 $ | [MP&W Supply](https://mpandw.ca/) |
+| 6 | Carte de protection de batterie, coupure haute et basse tension | 1 | 8 $ | [Space Hedgehog](https://space-hedgehog.com/products/battery-protection-with-low-voltage-cut-off) |
+| 7 | Filtre passe-bande à quatre cavités, 890–960 MHz, 50 W (recommandé) | 1 | 65 $ | [Alibaba](https://www.alibaba.com/product-detail/50W-890-960MHz-4-Cavity-Filter_1601399651944.html) |
+| 8 | Câble de 10–15 cm, SMA coudé vers connecteur N femelle de cloison avec joint torique et écrou | 1 | 6 $ | [AliExpress](https://www.aliexpress.com/item/1005008569444661.html) |
+| 9 | Câble de 7,5 cm, SMA mâle coudé à 90° aux deux extrémités | 1 | 7 $ | [AliExpress](https://www.aliexpress.com/item/1005006702037541.html) |
+| 10 | Câble de 0,5 pi, USB-A vers USB-C coudé | 1 | 7 $ | [Amazon](https://a.co/d/045htrEG) |
+| 11 | Entretoises M3x35 | 4 | — | — |
+| 12 | Vis M3x5 | 8 | — | — |
+| 13 | Époxy Gorilla en seringue, 25 ml | 1 | 15 $ | [Home Depot](https://www.homedepot.ca/product/gorilla-epoxy-syringe-25ml/1000778451) |
+| 14 | Évent étanche | 1 | 2 $ | [AliExpress](https://www.aliexpress.com/item/1005006370919409.html) |
+| 15 | Mastic silicone transparent pour l’extérieur | 1 | 10 $ | Quincaillerie |
+| 16 | Adafruit INA3221 (facultatif) | 1 | 15–20 $ | [DigiKey](https://www.digikey.ca/en/products/detail/adafruit-industries-llc/6062/25660599) |
 
 </div>
 
-<p class="mc-table-note">Ces pièces sont des pistes non vérifiées. Vérifiez les caractéristiques, la disponibilité, l’expédition et le coût total actuels avant d’acheter.</p>
+**Coût total estimé dans le guide d’origine :** environ **280–290 $ sans INA3221**, ou **300–310 $ avec INA3221**. L’antenne, les pièces imprimées en 3D et la visserie de montage ne sont pas comprises.
 
-## Outils et téléchargements
+**Autre filtre possible (solution minimale) :** filtre à cavité Callboost de 915 MHz, bande passante de 26 MHz, 82 $. [AliExpress](https://www.aliexpress.com/item/1005004468960058.html)
 
-Prévoyez des outils de soudage et de câblage, un multimètre, des forets et des
-outils de coupe appropriés, des serre-joints, une protection oculaire et un
-espace de travail sécuritaire.
+### Antenne
 
-Fichiers imprimables à vérifier :
+L’antenne n’est pas incluse, car le choix dépend de l’installation. Le guide d’origine recommande un gain de 6–8 dBi ou plus pour ce type de liaison. Plusieurs personnes à Ottawa ont observé une baisse de qualité du signal avec l’Ikoka Stick et l’antenne Alfa de 5,8 dBi. Il s’agit d’une observation sur ces installations, pas d’une incompatibilité établie.
 
-- [Plaque de montage et support de pile (.3mf)](files/repeater-solar-1w-diy-build-plate-and-battery-holder.3mf)
+Consultez les [antennes omnidirectionnelles GOME pour répéteurs](recommended-antenna.md#antennes-omnidirectionnelles-pour-repeteurs) pour les options présentées dans le guide.
+
+<span id="outils-et-telechargements"></span>
+
+## Outils nécessaires
+
+<div class="mc-table-wrap mc-build-table" markdown>
+
+| Outil | Notes |
+|---|---|
+| Fer à souder | Une panne fine facilite les connexions I2C |
+| Soudure et flux | |
+| Multimètre | Vérifications de continuité et de tension |
+| Foret étagé | Pour percer proprement la boîte de jonction |
+| Scie sauteuse ou outil rotatif | Pour découper l’ouverture du panneau solaire |
+| Foret de 1/8 po | Pour agrandir les trous de montage |
+| Crayon | Pour tracer la découpe |
+| Serre-joints et morceau de bois plat | Pour maintenir le panneau pendant le durcissement de l’époxy |
+| Pince à dénuder | |
+
+</div>
+
+<span id="prerequisites"></span>
+<span id="downloads"></span>
+
+## Pièces imprimées et téléchargements
+
+Imprimez ces deux pièces avant de commencer :
+
+- Une **plaque de montage** pour la boîte de jonction, qui porte le filtre, l’Ikoka et la carte Waveshare.
+- Un **support de trois batteries 18650 en parallèle**, ou un support adapté à votre bloc de batteries.
+
+Téléchargements :
+
+- [Plaque et support de batteries 3P1S, fichier combiné .3mf](files/repeater-solar-1w-diy-build-plate-and-battery-holder.3mf)
 - [Plaque de montage (.stl)](files/repeater-solar-1w-diy-build-plate.stl)
-- [Support de pile 18650 3P1S (.stl)](files/repeater-solar-1w-diy-build-3x18650-battery-holder.stl)
+- [Support de trois batteries 18650 (.stl)](files/repeater-solar-1w-diy-build-3x18650-battery-holder.stl)
 
-Confirmez les dimensions, le matériau, le rendement thermique, les attaches, le
-maintien de la pile et la qualité d’impression avant l’utilisation.
+<span id="ce-que-cette-construction-change"></span>
+<span id="etapes-dassemblage"></span>
 
-## Étapes d’assemblage
+## Étapes d’assemblage { #assembly-steps }
 
-<div class="mc-stage-list">
-  <section class="mc-build-stage" data-stage="stop">
-    <h3>Étape 1 — Examiner et vérifier l’ajustement à sec</h3>
-    <p>Confirmez toutes les révisions, les dimensions, les limites électriques, les parcours des connecteurs, l’orientation du filtre, les dégagements, les pièces imprimées, les courbures de câble, l’emplacement de l’évent, celui du panneau et l’accès pour l’entretien avant de couper ou de coller.</p>
-    <p><strong>Point de contrôle :</strong> le schéma, le parcours RF et la disposition mécanique examinés correspondent aux pièces exactes que vous avez en main.</p>
-  </section>
-  <section class="mc-build-stage">
-    <h3>Étape 2 — Préparer le boîtier et le panneau</h3>
-    <ol>
-      <li>Mesurez la boîte de jonction du panneau et marquez la découpe du boîtier à partir des pièces réelles.</li>
-      <li>Avec le boîtier vide et solidement soutenu, utilisez une ouverture pilote et un outil de coupe appropriés.</li>
-      <li>Ébavurez et nettoyez la découpe, puis vérifiez à sec l’ajustement du panneau et le passage du câble.</li>
-      <li>Collez et serrez seulement au moyen d’une méthode examinée et compatible avec les matériaux. Laissez durcir pendant toute la période indiquée par le fabricant.</li>
-      <li>Appliquez le joint d’étanchéité examiné sans bloquer le drainage ni l’aération.</li>
-    </ol>
-    <figure><img class="mc-build-photo" src="../images/repeater-solar-1w-diy-build-1.jpg" alt="Fils du panneau solaire passant dans la découpe du boîtier" loading="lazy"><figcaption>Exemple seulement. Mesurez les pièces réelles.</figcaption></figure>
-  </section>
-  <section class="mc-build-stage">
-    <h3>Étape 3 — Installer la plaque de montage, le filtre, la traversée et l’évent</h3>
-    <ol>
-      <li>Installez les entretoises et la plaque de montage examinées sans exercer de contrainte sur le boîtier.</li>
-      <li>Montez le filtre en repérant les ports d’entrée et de sortie et en conservant un rayon de courbure suffisant pour les câbles.</li>
-      <li>Percez et ébavurez les trous de la traversée et de l’évent en vérifiant l’ajustement du matériel réel.</li>
-      <li>Installez les joints, la traversée et l’évent selon leur documentation.</li>
-      <li>Laissez les raccords RF sans alimentation et accessibles pour l’inspection.</li>
-    </ol>
-    <figure><img class="mc-build-photo" src="../images/repeater-solar-1w-diy-build-2.jpg" alt="Plaque de montage avec entretoises et filtre RF" loading="lazy"><figcaption>Exemple de disposition de la plaque et du filtre.</figcaption></figure>
-    <figure><img class="mc-build-photo" src="../images/repeater-solar-1w-diy-build-3.jpg" alt="Boîtier avec filtre, câbles de traversée RF et bouchon d’évent" loading="lazy"><figcaption>Vérifiez le sens des connecteurs et chaque joint.</figcaption></figure>
-  </section>
-  <section class="mc-build-stage" data-stage="stop">
-    <h3>Étape 4 — Examiner la modification du démarrage du gestionnaire d’alimentation</h3>
-    <p><strong>Ne pontez pas les pastilles du bouton de démarrage du gestionnaire d’alimentation.</strong> Cette modification n’a pas été reproduite ni examinée.</p>
-    <p>Avant d’envisager tout changement, exigez qu’une personne qualifiée en électronique approuve le schéma exact, les modes de défaillance, les répercussions sur la garantie, la méthode de soudage, l’essai de démarrage et le retour en arrière.</p>
-    <figure><img class="mc-build-photo" src="../images/repeater-solar-1w-diy-build-4.jpg" alt="Pont de fil non vérifié sur les pastilles du bouton de démarrage du gestionnaire solaire" loading="lazy"><figcaption>Modification non vérifiée. Ne la reproduisez pas à partir de cette photographie.</figcaption></figure>
-  </section>
-  <section class="mc-build-stage" data-stage="stop">
-    <h3>Étape 5 — Monter la radio et décider de la télémétrie facultative</h3>
-    <p>Vérifiez à sec l’ajustement de l’Ikoka Stick et du gestionnaire d’alimentation. La branche facultative INA3221 retire l’embase de l’écran et se soude aux pastilles I2C; elle doit donc rester séparée de la construction de base.</p>
-    <p>Le brochage de télémétrie, le parcours de mesure, l’étalonnage, la plage de courant, l’adresse I2C et la prise en charge par le micrologiciel ne sont pas vérifiés.</p>
-    <p><strong>Par défaut :</strong> omettez la télémétrie facultative. Ne retirez pas les broches de l’écran et n’ajoutez pas d’options de micrologiciel avant d’avoir reproduit le matériel exact et la cible actuelle de MeshCore.</p>
-    <figure><img class="mc-build-photo" src="../images/repeater-solar-1w-diy-build-5.jpg" alt="Raccord facultatif non vérifié d’un INA3221 près de l’embase d’écran de l’Ikoka" loading="lazy"><figcaption>Télémétrie facultative non vérifiée. Ne la reproduisez pas à partir de cette photographie.</figcaption></figure>
-  </section>
-  <section class="mc-build-stage" data-stage="stop">
-    <h3>Étape 6 — Assembler le parcours de la pile et de la recharge</h3>
-    <ol>
-      <li>Gardez l’alimentation solaire, la pile, l’USB et la radio débranchés.</li>
-      <li>Confirmez la construction du bloc-pile, l’appariement des cellules, la protection, le maintien, l’isolation et les limites de température.</li>
-      <li>Confirmez chaque borne du gestionnaire d’alimentation et de la carte de protection dans la documentation actuelle des fabricants.</li>
-      <li>Mesurez et consignez la polarité; ne vous fiez pas à la couleur des fils.</li>
-      <li>Branchez une seule branche examinée à la fois et inspectez-la avant de continuer.</li>
-    </ol>
-    <p><strong>Point de contrôle :</strong> il ne reste aucune borne, limite ou valeur attendue inconnue, aucun conducteur exposé ni aucune condition de pile non prise en charge.</p>
-  </section>
-  <section class="mc-build-stage">
-    <h3>Étape 7 — Terminer les parcours RF et USB</h3>
-    <ol>
-      <li>Vérifiez le sens d’entrée et de sortie du filtre ainsi que chaque connecteur SMA et de type N.</li>
-      <li>Branchez tout le parcours d’antenne examiné avant que la radio puisse transmettre.</li>
-      <li>Acheminez le câble d’alimentation USB sans pli brusque, frottement ni tension.</li>
-      <li>Gardez le boîtier ouvert pendant la première mise sous tension supervisée et les vérifications.</li>
-    </ol>
-    <figure><img class="mc-build-photo" src="../images/repeater-solar-1w-diy-build-6.jpg" alt="Intérieur terminé avec télémétrie INA3221 facultative" loading="lazy"><figcaption>Disposition avec télémétrie facultative non vérifiée.</figcaption></figure>
-    <figure><img class="mc-build-photo" src="../images/repeater-solar-1w-diy-build-7.jpg" alt="Intérieur terminé sans télémétrie INA3221 facultative" loading="lazy"><figcaption>Exemple de disposition de base.</figcaption></figure>
-    <figure><img class="mc-build-photo" src="../images/repeater-solar-1w-diy-build-8.jpg" alt="Intérieur complet du boîtier avec radio, filtre, gestionnaire d’alimentation et pile" loading="lazy"><figcaption>Exemple d’intérieur. Une photographie ne constitue pas une approbation électrique.</figcaption></figure>
-  </section>
-</div>
+Gardez le panneau solaire, la batterie et l’USB débranchés pendant les découpes, les soudures et les modifications du câblage.
 
-## Vérifier les mesures
+### Préparer le boîtier
 
-Aucune plage numérique d’acceptation n’a été examinée par des pairs pour cette
-page. Ne remplacez pas les valeurs manquantes par des tensions ou des courants
-devinés.
+1. Posez le panneau solaire face contre le sol. À l’arrière, repérez le petit boîtier noir d’où sortent les fils rouge et noir. Mesurez-le à la règle ou au pied à coulisse.
 
-<div class="mc-table-wrap" markdown>
+2. Sur la **face avant** de la boîte de jonction grise, tracez un rectangle aux dimensions de ce petit boîtier. Centrez-le près du haut de la face.
 
-| Vérification | Résultat acceptable | Condition d’arrêt |
+3. Percez un trou de départ au centre du rectangle avec le foret étagé.
+
+4. Découpez le rectangle à la scie sauteuse ou à l’outil rotatif, puis ébavurez les bords.
+
+### Fixer le panneau solaire
+
+5. Mélangez l’époxy Gorilla et étalez-la sur toute la zone de la boîte de jonction qui recevra le panneau.
+
+6. Faites passer le câble du panneau par l’ouverture, de l’extérieur vers l’intérieur de la boîte.
+
+      [![Fils du panneau solaire passant dans l’ouverture de la boîte](images/repeater-solar-1w-diy-build-1.jpg){ .mc-build-photo width="300" height="400" loading=lazy }](images/repeater-solar-1w-diy-build-1.jpg)
+
+7. Pressez le panneau contre la face encollée. Placez un morceau de bois plat devant le panneau et serrez les quatre coins avec des serre-joints pour répartir la pression. Ne serrez pas trop : le panneau peut se fissurer. Vous pouvez aussi poser l’assemblage à plat et placer des poids sur l’arrière de la boîte.
+
+8. Laissez l’époxy durcir pendant toute la durée indiquée par le fabricant avant de retirer les serre-joints.
+
+9. Appliquez un cordon de silicone extérieur transparent sur les quatre côtés, à la jonction du panneau et de la boîte. Lissez-le pour former un joint étanche.
+
+### Installer la plaque et le filtre
+
+10. Fixez les quatre entretoises M3x35 aux coins de la plaque de montage. Au besoin, agrandissez légèrement les trous avec le foret de 1/8 po pour laisser passer les vis M3. Utilisez la plaque imprimée comme gabarit.
+
+      [![Plaque de montage avec entretoises et filtre](images/repeater-solar-1w-diy-build-2.jpg){ .mc-build-photo width="300" height="400" loading=lazy }](images/repeater-solar-1w-diy-build-2.jpg)
+
+11. Fixez le filtre passe-bande RF à peu près au centre de la plaque.
+
+12. Branchez le câble N vers SMA à la **sortie** du filtre. Il traversera la paroi de la boîte vers l’antenne extérieure.
+
+13. Choisissez l’emplacement du connecteur N sur la paroi. Percez au foret étagé en augmentant progressivement le diamètre et en essayant le connecteur à chaque étape.
+
+14. Passez le connecteur N de l’intérieur vers l’extérieur, puis serrez son écrou avec le joint torique.
+
+15. Percez un trou dans le **fond** de la boîte pour l’évent étanche.
+
+16. Installez et serrez l’évent.
+
+      [![Filtre dans le boîtier avec câbles SMA, connecteur N et évent](images/repeater-solar-1w-diy-build-3.jpg){ .mc-build-photo width="300" height="400" loading=lazy }](images/repeater-solar-1w-diy-build-3.jpg)
+
+### Préparer le filtre et la radio
+
+17. Branchez le câble SMA vers SMA à l’**entrée** du filtre. Serrez-le à la main pour le moment.
+
+18. **Waveshare Solar Power Manager, modèle standard :** le montage d’origine relie les pastilles du bouton BOOT avec un fil pour rétablir la sortie après une coupure de courant, sans appuyer sur le bouton. Avec toutes les alimentations débranchées, soudez un petit fil entre les pastilles au dos de la carte, comme sur la photo. Cette modification concerne le modèle standard; ne supposez pas que les versions B, C ou D utilisent le même circuit. Testez le redémarrage après une coupure avant de fermer le boîtier.
+
+      [![Fil soudé entre les pastilles du bouton BOOT du gestionnaire Waveshare](images/repeater-solar-1w-diy-build-4.jpg){ .mc-build-photo width="300" height="400" loading=lazy }](images/repeater-solar-1w-diy-build-4.jpg)
+
+### Monter les composants
+
+19. Pour faciliter l’accès, fixez l’Ikoka Stick et le gestionnaire Waveshare à la plaque de montage hors du boîtier. Installez aussi l’INA3221 si vous l’utilisez.
+
+20. **(INA3221 facultatif)** Dessoudez délicatement les broches de l’embase de l’écran OLED de l’Ikoka Stick. Travaillez lentement pour ne pas endommager les composants voisins.
+
+21. **(INA3221 facultatif)** Soudez les fils I2C de l’INA3221 aux pastilles de l’embase de l’écran. Les connexions sont indiquées dans la section [Câblage de l’INA3221](#ina3221-wiring-optional).
+
+      [![INA3221 relié au bus I2C de l’Ikoka avec le gestionnaire Waveshare](images/repeater-solar-1w-diy-build-5.jpg){ .mc-build-photo width="300" height="400" loading=lazy }](images/repeater-solar-1w-diy-build-5.jpg)
+
+22. Placez la plaque équipée dans la boîte et fixez-la aux entretoises M3x35 avec les vis M3x5.
+
+### Installer la batterie
+
+23. Fixez le support de batteries imprimé à l’intérieur de la face avant, sous l’entrée des fils du panneau solaire. Utilisez de l’adhésif double face ou de l’époxy.
+
+24. Si le bloc de batteries 18650 n’a pas de circuit de protection intégré (PCM), placez la carte de protection entre la batterie et le gestionnaire Waveshare. Respectez les indications de polarité.
+
+### Câbler l’alimentation
+
+25. **(INA3221 facultatif) Panneau solaire :** reliez le positif du panneau à **CH3+**, puis **CH3-** au positif de l’entrée solaire du Waveshare. Reliez directement le négatif du panneau au négatif de l’entrée solaire.
+
+26. **(INA3221 facultatif) Batterie :** reliez le positif de la batterie, ou de son PCM, à **CH1+**. Reliez **CH1-** au positif du connecteur de batterie JST PH2.0 du Waveshare. Reliez directement le négatif de la batterie au négatif du connecteur, puis branchez celui-ci sur la carte.
+
+      **Sans INA3221 :** branchez le panneau solaire et la batterie directement aux entrées solaire et batterie du Waveshare.
+
+### Terminer les connexions
+
+27. Branchez le câble SMA venant de l’entrée du filtre au connecteur SMA de l’Ikoka Stick. Serrez les deux extrémités avec une clé adaptée, sans tordre le câble ni trop serrer. Un connecteur desserré entraîne une perte de signal. Branchez l’antenne extérieure avant de mettre l’ensemble sous tension.
+
+28. Reliez la sortie USB-A du Waveshare à l’entrée USB-C de l’Ikoka Stick avec le câble USB.
+
+      *Montage terminé avec INA3221 :*
+
+      [![Montage terminé avec INA3221, Waveshare et Ikoka Stick](images/repeater-solar-1w-diy-build-6.jpg){ .mc-build-photo width="300" height="400" loading=lazy }](images/repeater-solar-1w-diy-build-6.jpg)
+
+      *Sans INA3221 :*
+
+      [![Montage terminé sans INA3221](images/repeater-solar-1w-diy-build-7.jpg){ .mc-build-photo width="300" height="400" loading=lazy }](images/repeater-solar-1w-diy-build-7.jpg)
+
+      *Vue complète de l’intérieur avec INA3221, bloc de batteries et câblage :*
+
+      [![Vue complète du boîtier terminé avec INA3221](images/repeater-solar-1w-diy-build-8.jpg){ .mc-build-photo width="300" height="225" loading=lazy }](images/repeater-solar-1w-diy-build-8.jpg)
+
+## Câblage de l’INA3221 (facultatif) { #ina3221-wiring-optional }
+
+L’Adafruit INA3221 se relie au bus I2C de l’Ikoka Stick par les pastilles de l’**embase d’écran OLED**. Retirez les broches de l’embase et soudez les fils directement aux pastilles.
+
+**Connexions I2C, de l’embase d’écran Ikoka vers l’INA3221 :**
+
+<div class="mc-table-wrap mc-build-table" markdown>
+
+| Embase d’écran Ikoka | Broche INA3221 | Fonction |
 |---|---|---|
-| Continuité débranchée | Aucun court-circuit involontaire dans les parcours d’alimentation ou RF documentés | Continuité inattendue ou configuration incertaine du multimètre |
-| Polarité des connecteurs | Les mesures correspondent au schéma examiné et au brochage du fabricant | Toute contradiction ou broche inconnue |
-| Valeurs solaires, de pile et de sortie | Chaque valeur mesurée respecte la documentation actuelle de tous les composants branchés | Limite manquante ou valeur hors limites |
-| Première mise sous tension | Démarrage stable et attendu, sans chaleur, odeur, enflure, fumée, bruit ni cycle de redémarrage | Tout comportement physique ou électrique anormal |
-| Parcours RF | Bande, sens du filtre et raccords exacts, avec l’antenne branchée avant la transmission | Antenne manquante, connecteur desserré ou forcé, réponse inconnue du filtre |
-| Télémétrie facultative | Mesures et comportement du micrologiciel reproduits indépendamment | Câblage, adresse, étalonnage ou cible de construction non vérifiés |
+| Broche 1 — GND | GND | Masse |
+| Broche 2 — VCC (3,3 V) | VCC | Alimentation |
+| Broche 3 — SCL | SCL | Horloge |
+| Broche 4 — SDA | SDA | Données |
 
 </div>
 
-## Le tester sur l’établi
+**Affectation des canaux INA3221 :**
 
-<ul class="mc-checklist">
-  <li>Consignez les pièces exactes, les révisions, les documents sources, le schéma, les photographies, la polarité et les valeurs mesurées.</li>
-  <li>Utilisez des méthodes supervisées de première mise sous tension et de limitation du courant adaptées au matériel examiné.</li>
-  <li>Confirmez que l’appareil démarre après l’application de chaque source d’alimentation prévue et après une coupure d’alimentation contrôlée.</li>
-  <li>Confirmez que l’identité, le micrologiciel et les réglages de radio, de région, de parcours, d’annonce et d’accès du répéteur sont conservés après le redémarrage.</li>
-  <li>Confirmez qu’un compagnon à proximité reçoit une annonce et que l’essai d’acheminement local prévu réussit.</li>
-  <li>Mesurez le comportement RF et électrique avec la méthode approuvée par la personne responsable de l’examen; ne déduisez pas la puissance de sortie à partir d’un seul réglage du micrologiciel.</li>
-  <li>Effectuez sous surveillance un essai de recharge et de charge qui couvre les conditions examinées sans dépasser les limites des composants.</li>
-  <li>Inspectez la tension des câbles et les joints, puis effectuez un essai de résistance à l’eau adapté au boîtier.</li>
-  <li>Démontrez la récupération USB et documentez le plan de retrait et d’accès.</li>
-</ul>
+<div class="mc-table-wrap mc-build-table" markdown>
 
-Ne déployez pas l’appareil avant qu’une personne responsable de l’examen du
-matériel et de l’électricité, une personne qualifiée en RF et le
-propriétaire du site aient approuvé le dossier d’essai complet.
+| Canal | Connexion | Fonction |
+|---|---|---|
+| CH1 | Batterie | Mesurer la tension et le courant de la batterie |
+| CH2 | Non utilisé | Disponible pour un ajout ultérieur |
+| CH3 | Panneau solaire | Mesurer la tension et le courant solaires |
 
-## Récupération et retour en arrière
+</div>
 
-Si une vérification échoue, cessez de transmettre et débranchez l’alimentation
-solaire, USB et de la pile selon la séquence sécuritaire examinée. Déplacez le
-matériel vers un espace de travail surveillé approprié. Ne rebranchez pas une
-pile au lithium chaude, gonflée, endommagée, qui fuit ou qui paraît autrement
-douteuse. Restaurez le micrologiciel par USB seulement après avoir compris le
-problème électrique ou RF.
+**Note :** VCC alimente l’INA3221 en 3,3 V depuis l’Ikoka. VIN1, VIN2 et VIN3 sont les entrées de mesure, pas la broche d’alimentation.
 
-Les découpes, l’époxy, les broches retirées et les ponts de soudure peuvent être
-irréversibles. Remplacez les composants douteux plutôt que d’improviser une
-réparation. Pour revenir de façon sécuritaire sur la branche de télémétrie
-facultative, omettez-la avant toute modification; ne supposez pas que le
-matériel retiré pourra être restauré.
+### Options de compilation du micrologiciel
 
-## Entretien
+MeshCore utilise l’adresse `0x42` par défaut; l’Adafruit INA3221 utilise `0x40`. Conservez les options héritées de la carte et ajoutez ces réglages à l’environnement du répéteur 30 dBm :
 
-Aucun intervalle n’est approuvé. Le dossier du site doit définir les
-inspections du montage, du panneau et de son collage, des infiltrations d’eau,
-de l’évent, des joints, de la corrosion, des câbles et connecteurs, du filtre,
-de l’état de la pile, du comportement de recharge, des valeurs mesurées, du
-micrologiciel et de la configuration, de la vérification radio et de la
-récupération physique. Reprenez l’inspection après tout événement grave ou
-comportement inexpliqué défini par la personne responsable de l’examen du site.
+```ini
+[env:ikoka_stick_nrf_30dbm_repeater]
+build_flags =
+  ${ikoka_stick_nrf_repeater.build_flags}
+  ${ikoka_stick_nrf_e22_30dbm.build_flags}
+  -D TELEM_INA3221_ADDRESS=0x40
+  -UENV_INCLUDE_INA219
+  -D TELEM_INA3221_SHUNT_VALUE=0.05
+```
+
+Les options d’adresse et d’INA219 viennent du guide d’origine : elles sélectionnent `0x40` et désactivent le pilote INA219 pour éviter un conflit. L’option de résistance shunt correspond aux résistances de **0,05 Ω** de la carte Adafruit et corrige l’échelle des mesures de courant. Voir le [brochage Adafruit](https://learn.adafruit.com/adafruit-ina3221-breakout/pinouts) et les [réglages de capteurs MeshCore](https://github.com/meshcore-dev/MeshCore/blob/main/src/helpers/sensors/EnvironmentSensorManager.cpp).
+
+## Schéma de câblage { #wiring-diagram }
+
+[![Schéma de câblage du répéteur solaire Ikoka avec INA3221](images/repeater-solar-1w-diy-build-9.svg){ .mc-build-photo .mc-build-diagram width="600" height="543" loading=lazy }](images/repeater-solar-1w-diy-build-9.svg)
+
+<span id="le-tester-sur-letabli"></span>
+
+## Vérifier avant la mise sous tension { #verifier-les-mesures }
+
+- Vérifiez la polarité et la continuité, puis inspectez les soudures pour repérer les courts-circuits.
+- Utilisez un bloc 1S protégé, composé de cellules assorties, et respectez leur plage de températures de charge.
+- Vérifiez les connexions de l’antenne, du filtre et des câbles RF.
+- Mesurez la sortie USB du gestionnaire d’alimentation avant de brancher la radio.
+- Testez le retour de l’alimentation après une coupure. Si vous avez installé l’INA3221, comparez ses mesures à celles du multimètre.
+- [Programmez et configurez le répéteur](../start/repeater.md), puis vérifiez qu’un compagnon proche reçoit son annonce avant de l’installer.
+
+## Dépannage et récupération { #recuperation-et-retour-en-arriere }
+
+Si le répéteur ne démarre pas, débranchez l’alimentation et revérifiez le câblage ainsi que la modification du bouton BOOT. N’utilisez plus une batterie chaude, gonflée, endommagée ou qui fuit. Si une mise à jour du micrologiciel échoue, suivez les [étapes de récupération par USB](../meshcore/flash-repeater.md#plan-de-recuperation) après avoir vérifié l’alimentation et les connexions RF.
+
+<span id="entretien"></span>
+
+Après l’installation, inspectez régulièrement le montage, le collage du panneau, les joints, l’évent, les câbles et la batterie, ainsi qu’après de fortes intempéries.
 
 ## Source
 
-Fondé sur des notes expérimentales fournies par MrAlders0n en 2026. Aucune
-affirmation concernant le matériel ou le micrologiciel de cette page n’est
-vérifiée.
+Restauration du [guide de MrAlders0n publié avant la refonte](https://github.com/MeshCore-ca/MeshCore-Canada/blob/76a4262a354a111d19ddf8cc4abb25b1267fd9db/docs/hardware/repeater-solar-1w-diy-build.md). Les pièces, l’ordre d’assemblage, les photos, les tableaux de câblage et les téléchargements d’origine sont conservés. L’exemple de télémétrie facultative précise aussi la résistance shunt de la carte Adafruit.
 
-Privilégiez une option examinée du
-[guide de sélection des répéteurs](recommended-repeaters.md). Si cette
-expérience est approuvée et mise en service, terminez le
-[plan de montage](repeater-mounting-options.md) et la
-[configuration du répéteur](../config/index.md).
+Consultez le [manuel Waveshare](https://files.waveshare.com/upload/6/6c/Solar_Power_Manager_user_manual_en.pdf) pour les limites et les bornes du gestionnaire d’alimentation standard.

--- a/docs/hardware/repeater-solar-1w-diy-build.md
+++ b/docs/hardware/repeater-solar-1w-diy-build.md
@@ -1,231 +1,301 @@
 ---
-title: Experimental 1 W solar repeater
-description: Evaluate an unverified high-power solar repeater design before deciding whether to reproduce it.
+title: Build a 1 W solar repeater with the Ikoka Stick
+description: Parts, prices, assembly photos, wiring diagram, and optional INA3221 telemetry for MrAlders0n's Ikoka Stick solar repeater build.
 audience:
   - advanced-repeater-builder
-  - hardware-reviewer
-task: review-1w-solar-repeater-build
-scope: experimental
-status: experimental
+task: build-1w-solar-repeater
+scope: ottawa-field-practice
+status: draft
 status_notice: false
 owner: docs-hardware
-last_reviewed: 2026-07-22
+last_reviewed: 2026-09-09
 review_by: 2026-10-17
 difficulty: advanced
 estimated_time: multiple days including fabrication and cure time
-destructive: false
+destructive: true
 requires:
   - multimeter
   - soldering-experience
   - fabrication-experience
   - manufacturer-documentation
 page_styles:
-  - assets/styles/devices-builds.css?v=20260728-1
+  - assets/styles/devices-builds.css?v=20260909-1
 ---
 
-# Experimental 1 W Solar Repeater
+<span id="experimental-1-w-solar-repeater"></span>
+<span id="building-a-1w-solar-repeater-ikoka-stick"></span>
 
-This unverified design combines an Ikoka Stick 0.4.0, a solar power manager,
-a filtered RF path, and a fabricated enclosure.
+# Building a 1 W solar repeater — Ikoka Stick
 
-<div class="mc-guide-status" data-status="experimental" markdown>
+By **MrAlders0n (Ottawa)** · Original guide: **January 1, 2026**
 
-**Do not build or deploy this design without electrical, RF, and site review.**
-Its firmware target, electrical design, optional telemetry, measurements, and
-climate limits have not been reproduced.
+Build a solar-powered MeshCore repeater using a GOME Ikoka Stick, a junction box enclosure, and an epoxied solar panel.
 
-</div>
-
-<dl class="mc-guide-facts">
-  <div><dt>Radio</dt><dd>GOME Ikoka Stick 0.4.0</dd></div>
-  <div><dt>Power</dt><dd>Waveshare Solar Power Manager</dd></div>
-  <div><dt>Firmware</dt><dd>Not pinned or reproduced</dd></div>
-  <div><dt>Maintenance</dt><dd>Set during the site review</dd></div>
-</dl>
-
-## Is this build appropriate?
-
-This is a specialized backbone or long-range experiment, not a default
-upgrade. Coordinate with nearby communities and show that the site needs it
-before changing coverage or traffic patterns.
-
-Use the [300 mW draft build](repeater-solar-300mw-diy-build.md) or a reviewed pre-built path unless a network operator and hardware/RF reviewer agree that this experiment addresses a measured need.
+**Board:** GOME Ikoka Stick (HW v0.4.0)<br>
+**Power:** Waveshare Solar Power Manager (standard)<br>
+**Firmware:** MeshCore
 
 ## Before you start
 
-!!! danger "This combines high-power RF, lithium batteries, charging, soldering, cutting, and an outdoor elevated installation"
-    Verify every component and limit from current manufacturer documentation. Keep an antenna and reviewed RF path attached before any transmit test. Do not energize a battery or charger path when polarity, protection, wiring, temperature, or expected readings are unknown.
+!!! warning "No warranty"
+    This community build guide is provided without a warranty. Check continuity and polarity with a multimeter before applying power. Disconnect solar, battery, and USB power before soldering or changing wiring.
 
-<ul class="mc-checklist">
-  <li>The local network need and cross-region effects are documented.</li>
-  <li>The exact Ikoka hardware and repeater firmware target are confirmed and recoverable by USB.</li>
-  <li>A hardware/electrical reviewer approves the battery, charger, panel, wiring, protection, optional telemetry, and enclosure thermal plan.</li>
-  <li>An RF reviewer approves the radio, filter, feed line, antenna, connectors, and site.</li>
-  <li>A structural/site review covers the finished mass, panel area, mount, wind, ice, snow, cable route, and access.</li>
-  <li>The build will remain supervised on the bench until its test record is approved.</li>
-</ul>
+<span id="is-this-build-appropriate"></span>
 
-## What this build changes
+!!! info "When to use a 1 W repeater"
+    1 W repeaters are useful for backbone links and locations struggling to connect to the mesh. They are not needed at every site; coordinate with your local community.
 
-The procedure cuts and drills an enclosure, bonds a solar panel with epoxy and sealant, modifies the mounting system, connects a high-power RF path and filter, assembles a lithium power system, and may remove display pins for optional telemetry. Several changes are difficult or impossible to undo without replacing parts.
+!!! danger "Antenna required"
+    **Attach a LoRa antenna before powering the Ikoka Stick. Transmitting without an antenna can permanently damage the radio.** Use the [MeshCore power setting for your exact Ikoka radio module](https://github.com/meshcore-dev/MeshCore/blob/main/docs/faq.md#77-q-i-have-a-station-g2-or-a-heltec-v4-or-an-ikoka-stick-or-a-radio-with-an-ebyte-e22-900m30s-or-an-ebyte-e22-900m33s-module-what-should-their-transmit-power-be-set-to); a 1 W output rating is not an instruction to set TX power to 30 dBm.
 
-## Bill of materials to verify
+<span id="bill-of-materials-to-verify"></span>
 
-<div class="mc-table-wrap" markdown>
+## Parts list
 
-| # | Part | Qty | Detail to verify | Source |
-|---:|---|---:|---|---|
-| 1 | GOME Ikoka Stick 0.4.0 | 1 | Hardware revision, Canadian band, RF output, firmware target, recovery | [Project page](https://github.com/ndoo/ikoka-stick-meshtastic-device) |
-| 2 | Waveshare Solar Power Manager | 1 | Exact model, panel, battery and output limits, startup behaviour, temperature | [Waveshare](https://www.waveshare.com/wiki/Solar_Power_Manager) |
-| 3 | IP65 junction box, 220×170×110 mm | 1 | Material, ingress rating after modification, temperature, vent | [AliExpress](https://www.aliexpress.com/item/1005007587120013.html) |
-| 4 | 10 W / 18 V panel, 250×340 mm | 1 | Electrical limits, dimensions, mass, weather and load suitability | [Amazon](https://a.co/d/0eJo5GCr) |
-| 5 | 3P1S or 4P1S 18650 pack | 1 | Chemistry, matched cells, protection, construction, charger, temperature | [MP&W Supply](https://mpandw.ca/) |
-| 6 | Battery protection board | 1 | Thresholds, current, temperature, wiring, compatibility | [Space Hedgehog](https://space-hedgehog.com/products/battery-protection-with-low-voltage-cut-off) |
-| 7 | 890–960 MHz four-cavity band-pass filter, 50 W | 1 | Response at 902–928 MHz, insertion loss, connectors, weather, temperature | [Alibaba](https://www.alibaba.com/product-detail/50W-890-960MHz-4-Cavity-Filter_1601399651944.html) |
-| 8 | 10–15 cm SMA right-angle to N-type female bulkhead cable | 1 | Connector gender and polarity, loss, bend, seal | [AliExpress](https://www.aliexpress.com/item/1005008569444661.html) |
-| 9 | 7.5 cm SMA male right-angle cable | 1 | Connector match, loss, bend, power handling | [AliExpress](https://www.aliexpress.com/item/1005006702037541.html) |
-| 10 | 0.5 ft USB-A to USB-C right-angle cable | 1 | Data and power needs, current, fit, strain | [Amazon](https://a.co/d/045htrEG) |
-| 11–12 | M3×35 spacers and M3×5 screws | as needed | Material, strength, fit, corrosion | Local source |
-| 13 | Gorilla Epoxy, 25 ml | 1 | Material compatibility, cure, outdoor and temperature limits | [Home Depot](https://www.homedepot.ca/product/gorilla-epoxy-syringe-25ml/1000778451) |
-| 14 | Waterproof vent plug | 1 | Thread, airflow, ingress performance after install | [AliExpress](https://www.aliexpress.com/item/1005006370919409.html) |
-| 15 | Clear outdoor silicone sealant | 1 | Material compatibility, cure, UV and temperature limits | Local hardware source |
-| 16 | Adafruit INA3221, optional | 1 | Electrical interface, address, firmware support, isolation, calibration | [DigiKey](https://www.digikey.ca/en/products/detail/adafruit-industries-llc/6062/25660599) |
+Prices are from the original guide dated **January 1, 2026**, not current quotes. All amounts are in Canadian dollars; check availability, shipping, and taxes before ordering.
+
+<div class="mc-table-wrap mc-build-table mc-parts-table" markdown>
+
+| # | Part | Qty | Price | Source |
+|---|------|-----|-------|--------|
+| 1 | GOME Ikoka Stick (HW v0.4.0) | 1 | $55 | [GitHub](https://github.com/ndoo/ikoka-stick-meshtastic-device) (group buy) |
+| 2 | Waveshare Solar Power Manager (standard) | 1 | $15 | [Waveshare](https://www.waveshare.com/wiki/Solar_Power_Manager) |
+| 3 | IP65 Junction Box, 220x170x110mm, Gray | 1 | $30 | [AliExpress](https://www.aliexpress.com/item/1005007587120013.html) |
+| 4 | Solar panel, 10W/18V, 250x340mm | 1 | $35 | [Amazon](https://a.co/d/0eJo5GCr) |
+| 5 | 3P1S 18650 battery pack (or 4P1S) | 1 | $25-35 | [MP&W Supply](https://mpandw.ca/) |
+| 6 | Battery protection board (high/low voltage cutoff) | 1 | $8 | [Space Hedgehog](https://space-hedgehog.com/products/battery-protection-with-low-voltage-cut-off) |
+| 7 | 890-960MHz 4-cavity bandpass filter, 50W (recommended) | 1 | $65 | [Alibaba](https://www.alibaba.com/product-detail/50W-890-960MHz-4-Cavity-Filter_1601399651944.html) |
+| 8 | 10-15cm SMA right angle to N-Type female O-ring nut cable | 1 | $6 | [AliExpress](https://www.aliexpress.com/item/1005008569444661.html) |
+| 9 | 7.5cm SMA Male 90° to SMA Male 90° cable | 1 | $7 | [AliExpress](https://www.aliexpress.com/item/1005006702037541.html) |
+| 10 | 0.5ft USB-A to USB-C right angle cable | 1 | $7 | [Amazon](https://a.co/d/045htrEG) |
+| 11 | M3x35 spacers | 4 | | |
+| 12 | M3x5 screws | 8 | | |
+| 13 | Gorilla Epoxy Syringe, 25ml | 1 | $15 | [Home Depot](https://www.homedepot.ca/product/gorilla-epoxy-syringe-25ml/1000778451) |
+| 14 | Waterproof vent plug (breather valve) | 1 | $2 | [AliExpress](https://www.aliexpress.com/item/1005006370919409.html) |
+| 15 | Outdoor silicone caulk (clear) | 1 | $10 | Any hardware store |
+| 16 | Adafruit INA3221 (optional) | 1 | $15-20 | [DigiKey](https://www.digikey.ca/en/products/detail/adafruit-industries-llc/6062/25660599) |
 
 </div>
 
-<p class="mc-table-note">These parts are unverified leads. Check current specifications, availability, shipping, and total cost before buying.</p>
+**Estimated total cost:** ~$280-290 without the INA3221, ~$300-310 with it. This does not include the antenna, 3D-printed parts, or mounting hardware (M3 spacers/screws).
 
-## Tools and downloads
+**Alternative filter option (minimal):** Callboost 915MHz cavity filter, 26M BW, $82. [AliExpress](https://www.aliexpress.com/item/1005004468960058.html)
 
-Plan for soldering and wire tools, a multimeter, suitable drills and cutting
-tools, clamps, eye protection, and a safe work area.
+### Antenna
 
-Printable files to verify:
+An antenna is not included in this parts list as selection will vary by deployment. It is highly recommended to use a higher dBi antenna such as a 6-8 dBi or higher with 1W builds. We have found that the Ikoka Stick does not pair well with the Alfa 5.8 dBi antenna for some reason, with several folks in Ottawa observing noticeably worse signal quality when using them together. This is not a definitive statement, just a pattern observed across multiple deployments.
 
-- [Mounting plate and battery holder (.3mf)](files/repeater-solar-1w-diy-build-plate-and-battery-holder.3mf)
+For recommended antenna options, see the [GOME Repeater Omni Antennas](recommended-antenna.md#repeater-omni-antennas) page.
+
+<span id="tools-and-downloads"></span>
+
+## Tools required
+
+<div class="mc-table-wrap mc-build-table" markdown>
+
+| Tool | Notes |
+|------|-------|
+| Soldering iron | Fine tip recommended for I2C wiring |
+| Solder + flux | |
+| Multimeter | For continuity and voltage checks |
+| Step drill bit | For drilling clean holes in the junction box |
+| Jigsaw or rotary tool | For cutting the solar panel opening |
+| 1/8" drill bit | For opening up mounting holes |
+| Pencil | For marking the cutout |
+| Clamps + flat piece of wood | For clamping solar panel during epoxy cure |
+| Wire strippers | |
+
+</div>
+
+<span id="prerequisites"></span>
+<span id="downloads"></span>
+
+## Printed parts and downloads
+
+Before starting assembly, you will need the following 3D-printed parts. Both are available for download below:
+
+- **Mounting plate** for the junction box (holds the filter, Ikoka, and Waveshare board)
+- **3P1S 18650 battery holder** (or sized to match your chosen battery configuration)
+
+- [Mounting plate + 3P1S 18650 battery holder (combined .3mf)](files/repeater-solar-1w-diy-build-plate-and-battery-holder.3mf)
 - [Mounting plate (.stl)](files/repeater-solar-1w-diy-build-plate.stl)
 - [3P1S 18650 battery holder (.stl)](files/repeater-solar-1w-diy-build-3x18650-battery-holder.stl)
 
-Confirm dimensions, material, temperature performance, fasteners, battery restraint, and print quality before use.
+<span id="what-this-build-changes"></span>
+<span id="assembly-stages"></span>
 
-## Assembly stages
+## Assembly steps
 
-<div class="mc-stage-list">
-  <section class="mc-build-stage" data-stage="stop">
-    <h3>Stage 1 — Review and dry-fit</h3>
-    <p>Confirm all revisions, dimensions, electrical limits, connector paths, filter orientation, clearances, printed parts, cable bends, vent location, panel location, and service access before cutting or bonding.</p>
-    <p><strong>Checkpoint:</strong> the reviewed schematic, RF path, and mechanical layout agree with the exact parts in hand.</p>
-  </section>
-  <section class="mc-build-stage">
-    <h3>Stage 2 — Prepare the enclosure and panel</h3>
-    <ol>
-      <li>Measure the panel junction box and mark the enclosure cutout from the actual parts.</li>
-      <li>Use an appropriate pilot opening and cutting tool with the enclosure empty and safely supported.</li>
-      <li>Deburr and clean the cutout, then dry-fit the panel and cable route.</li>
-      <li>Bond and clamp only with a reviewed material-compatible process. Let it cure for the full manufacturer time.</li>
-      <li>Apply the reviewed weather seal without blocking drainage or venting.</li>
-    </ol>
-    <figure><img class="mc-build-photo" src="../images/repeater-solar-1w-diy-build-1.jpg" alt="Solar-panel wires routed through the enclosure cutout" loading="lazy"><figcaption>Example only. Measure the actual parts.</figcaption></figure>
-  </section>
-  <section class="mc-build-stage">
-    <h3>Stage 3 — Install the mounting plate, filter, bulkhead, and vent</h3>
-    <ol>
-      <li>Fit the reviewed spacers and mounting plate without stressing the enclosure.</li>
-      <li>Mount the filter with identified input and output ports and adequate cable bend radius.</li>
-      <li>Drill and deburr the bulkhead and vent holes by test-fitting the actual hardware.</li>
-      <li>Install seals, bulkhead, and vent according to their documentation.</li>
-      <li>Leave RF connections unpowered and accessible for inspection.</li>
-    </ol>
-    <figure><img class="mc-build-photo" src="../images/repeater-solar-1w-diy-build-2.jpg" alt="Mounting plate with spacers and RF filter" loading="lazy"><figcaption>Example plate and filter layout.</figcaption></figure>
-    <figure><img class="mc-build-photo" src="../images/repeater-solar-1w-diy-build-3.jpg" alt="Enclosure with filter, RF bulkhead cables, and vent plug" loading="lazy"><figcaption>Check connector direction and every seal.</figcaption></figure>
-  </section>
-  <section class="mc-build-stage" data-stage="stop">
-    <h3>Stage 4 — Review the power-manager startup modification</h3>
-    <p><strong>Do not bridge the power manager's boot-button pads.</strong> That modification has not been reproduced or reviewed.</p>
-    <p>Before considering any change, require the exact schematic, failure modes, warranty impact, soldering method, startup test, and rollback to be approved by a hardware reviewer.</p>
-    <figure><img class="mc-build-photo" src="../images/repeater-solar-1w-diy-build-4.jpg" alt="Unverified wire bridge across solar-manager boot-button pads" loading="lazy"><figcaption>Unverified modification. Do not reproduce it from this photograph.</figcaption></figure>
-  </section>
-  <section class="mc-build-stage" data-stage="stop">
-    <h3>Stage 5 — Mount the radio and decide on optional telemetry</h3>
-    <p>Dry-fit the Ikoka Stick and power manager. The optional INA3221 branch removes the display header and solders to I2C pads, so it must remain separate from the base build.</p>
-    <p>The telemetry pinout, measurement path, calibration, current range, I2C address, and firmware support are not verified.</p>
-    <p><strong>Default:</strong> omit optional telemetry. Do not remove display pins or add firmware flags until the exact hardware and current MeshCore target are reproduced.</p>
-    <figure><img class="mc-build-photo" src="../images/repeater-solar-1w-diy-build-5.jpg" alt="Unverified optional INA3221 connection to the Ikoka display-header area" loading="lazy"><figcaption>Unverified optional telemetry. Do not reproduce it from this photograph.</figcaption></figure>
-  </section>
-  <section class="mc-build-stage" data-stage="stop">
-    <h3>Stage 6 — Assemble the battery and charging path</h3>
-    <ol>
-      <li>Keep solar, battery, USB, and radio disconnected.</li>
-      <li>Confirm the battery pack construction, cell matching, protection, restraint, insulation, and temperature limits.</li>
-      <li>Confirm every power-manager and protection-board terminal from current manufacturer documentation.</li>
-      <li>Measure and record polarity; do not rely on wire colour.</li>
-      <li>Connect one reviewed branch at a time and inspect before proceeding.</li>
-    </ol>
-    <p><strong>Checkpoint:</strong> no unknown terminal, limit, expected value, exposed conductor, or unsupported battery condition remains.</p>
-  </section>
-  <section class="mc-build-stage">
-    <h3>Stage 7 — Complete the RF and USB paths</h3>
-    <ol>
-      <li>Verify filter input/output direction and every SMA/N-type connector.</li>
-      <li>Attach the complete reviewed antenna path before the radio can transmit.</li>
-      <li>Route the USB power cable without sharp bends, abrasion, or strain.</li>
-      <li>Keep the enclosure open for supervised first power and checks.</li>
-    </ol>
-    <figure><img class="mc-build-photo" src="../images/repeater-solar-1w-diy-build-6.jpg" alt="Completed interior with optional INA3221 telemetry" loading="lazy"><figcaption>Unverified optional-telemetry layout.</figcaption></figure>
-    <figure><img class="mc-build-photo" src="../images/repeater-solar-1w-diy-build-7.jpg" alt="Completed interior without optional INA3221 telemetry" loading="lazy"><figcaption>Example base layout.</figcaption></figure>
-    <figure><img class="mc-build-photo" src="../images/repeater-solar-1w-diy-build-8.jpg" alt="Full enclosure interior with radio, filter, power manager, and battery" loading="lazy"><figcaption>Example interior. A photograph is not electrical approval.</figcaption></figure>
-  </section>
+Keep the solar panel, battery, and USB disconnected while cutting, soldering, or changing wiring.
+
+### Enclosure Preparation
+
+1. Flip the solar panel face-down. On the back, locate the black junction box where the red and black power wires exit. Measure this junction box with calipers or a ruler.
+
+2. On the **front face** of the gray junction box, use a pencil to trace a rectangle matching the solar panel junction box dimensions. Center it near the top of the panel.
+
+3. Using a step drill bit, drill a large starter hole in the center of the traced rectangle.
+
+4. Using a jigsaw or rotary tool, cut along the traced lines to remove the rectangular section. Clean up any rough edges.
+
+### Mounting the Solar Panel
+
+5. Mix a batch of Gorilla Epoxy and apply it generously across the entire front face of the junction box, covering the area where the solar panel will sit.
+
+6. Route the solar panel's power cable through the rectangular cutout from the outside into the box.
+
+      [![Solar panel wires routed through junction box](images/repeater-solar-1w-diy-build-1.jpg){ .mc-build-photo width="300" height="400" loading=lazy }](images/repeater-solar-1w-diy-build-1.jpg)
+
+7. Press the solar panel onto the epoxied face of the junction box. Place a flat piece of wood across the front of the panel and use clamps on all four corners to apply even pressure. Be careful not to over-tighten, as this can crack the panel. Alternatively, lay the assembly flat on the ground with weights on the back of the box.
+
+8. Allow the epoxy to fully cure according to the manufacturer's instructions before removing the clamps.
+
+9. Using clear outdoor silicone caulk, apply a bead around all four edges where the solar panel meets the junction box. Smooth the caulk to create a weatherproof seal.
+
+### Mounting Plate and Filter
+
+10. Attach the four M3x35 spacers to the corners of the junction box mounting plate. You may need to use a 1/8" drill bit to open the holes slightly to fit M3 screws through the plate. Use the 3D-printed mount plate as a reference for hole placement.
+
+      [![Mounting plate with spacers and filter assembled](images/repeater-solar-1w-diy-build-2.jpg){ .mc-build-photo width="300" height="400" loading=lazy }](images/repeater-solar-1w-diy-build-2.jpg)
+
+11. Mount the RF bandpass filter to the mounting plate, positioning it roughly in the center.
+
+12. Connect the N-Type to SMA cable to the filter's **output** port. This cable will pass through the box wall to the external antenna.
+
+13. Determine where the N-Type connector should exit the junction box. Using a step drill bit, drill the hole, stepping up one size at a time and test-fitting after each step until the connector fits snugly.
+
+14. Feed the N-Type connector through the box wall from the inside out and tighten the O-ring nut to secure it.
+
+15. On the **bottom** of the junction box, drill a hole for the waterproof vent plug using the step drill bit.
+
+16. Install the vent plug and tighten it.
+
+      [![Filter mounted in box with N-Type, SMA cables, and vent plug installed](images/repeater-solar-1w-diy-build-3.jpg){ .mc-build-photo width="300" height="400" loading=lazy }](images/repeater-solar-1w-diy-build-3.jpg)
+
+### Filter and Radio Preparation
+
+17. Connect the SMA-to-SMA cable to the filter's **input** port. Finger-tighten for now.
+
+18. **Waveshare Solar Power Manager prep (standard model):** The original build uses a wire bridge across the BOOT button pads so that output resumes after a power loss without a button press. With all power disconnected, solder a short wire across the pads on the back of the board, as shown below. This modification is specific to the standard model; do not assume the B, C, or D versions use the same circuit. Test power-loss recovery before sealing the enclosure.
+
+      [![Boot button shorted on Waveshare Solar Power Manager](images/repeater-solar-1w-diy-build-4.jpg){ .mc-build-photo width="300" height="400" loading=lazy }](images/repeater-solar-1w-diy-build-4.jpg)
+
+### Component Mounting
+
+19. Outside the box (for easier access), mount the Ikoka Stick and the Waveshare Solar Power Manager to the 3D-printed mounting plate. If using the optional INA3221, mount it as well.
+
+20. **(Optional, Adafruit INA3221)** Using a soldering iron, carefully remove the Ikoka Stick's OLED display header pins. Work slowly and gently to avoid damaging nearby components.
+
+21. **(Optional, Adafruit INA3221)** Solder the INA3221 to the Ikoka's I2C bus using the display header pads. See the [INA3221 Wiring](#ina3221-wiring-optional) section below for the pin connections.
+
+      [![INA3221 wired to Ikoka Stick I2C with Waveshare Solar Power Manager](images/repeater-solar-1w-diy-build-5.jpg){ .mc-build-photo width="300" height="400" loading=lazy }](images/repeater-solar-1w-diy-build-5.jpg)
+
+22. Install the mounting plate assembly into the junction box and secure it with M3x5 screws into the M3x35 spacers.
+
+### Battery Installation
+
+23. Attach the 3D-printed battery holder to the inside front of the case, below where the solar panel wires enter. Use double-sided tape or epoxy to secure it.
+
+24. If your 18650 battery pack does not have a built-in PCM (protection circuit module), wire the battery protection board between the battery and the Waveshare. Follow the polarity markings carefully.
+
+### Power Wiring
+
+25. **(Optional, Adafruit INA3221) Solar wiring:** Connect the solar panel positive wire to INA3221 **CH3+**. Connect CH3- to the Waveshare solar input positive. Connect the solar panel negative wire directly to the Waveshare solar input negative.
+
+26. **(Optional, Adafruit INA3221) Battery wiring:** Connect the battery (or the PCM) positive wire to INA3221 **CH1+**. Connect CH1- to the positive pin on the Waveshare battery JST PH2.0 connector. Connect the battery negative wire directly to the negative pin on the JST PH2.0 connector. Plug the connector into the Waveshare board.
+
+      **Note:** If you are not using the INA3221, wire the solar panel and battery directly to the Waveshare board's solar and battery inputs.
+
+### Final Connections
+
+27. Connect the SMA cable from the filter's input to the Ikoka Stick's SMA connector. Snug both ends with a suitable wrench without twisting the cable or overtightening. A loose RF connection will cause signal loss. Attach the external antenna before applying power.
+
+28. Run the USB-A to USB-C cable from the Waveshare Solar Power Manager's USB output to the Ikoka Stick's USB-C input.
+
+      *If using the Adafruit INA3221, your completed assembly should look similar to this:*
+
+      [![Completed build with INA3221, Waveshare, and Ikoka Stick](images/repeater-solar-1w-diy-build-6.jpg){ .mc-build-photo width="300" height="400" loading=lazy }](images/repeater-solar-1w-diy-build-6.jpg)
+
+      *Without the INA3221:*
+
+      [![Completed build without INA3221](images/repeater-solar-1w-diy-build-7.jpg){ .mc-build-photo width="300" height="400" loading=lazy }](images/repeater-solar-1w-diy-build-7.jpg)
+
+      *Full interior view with INA3221, battery pack, and all wiring complete:*
+
+      [![Full interior view of completed build with INA3221](images/repeater-solar-1w-diy-build-8.jpg){ .mc-build-photo width="300" height="225" loading=lazy }](images/repeater-solar-1w-diy-build-8.jpg)
+
+## INA3221 wiring (optional)
+
+The Adafruit INA3221 connects to the Ikoka Stick via I2C using the **OLED display header** pads. Remove the display header pins and solder wires directly to the pads.
+
+**I2C connection (Ikoka display header to INA3221):**
+
+<div class="mc-table-wrap mc-build-table" markdown>
+
+| Ikoka Display Header | INA3221 Pin | Wire |
+|----------------------|-------------|------|
+| Pin 1 - GND | GND | Ground |
+| Pin 2 - VCC (3.3V) | VCC | Power |
+| Pin 3 - SCL | SCL | Clock |
+| Pin 4 - SDA | SDA | Data |
+
 </div>
 
-## Check the readings
+**INA3221 channel assignments:**
 
-No numeric acceptance range has been peer-reviewed for this page. Do not substitute guessed voltages or currents.
+<div class="mc-table-wrap mc-build-table" markdown>
 
-<div class="mc-table-wrap" markdown>
-
-| Check | Acceptable result | Stop condition |
-|---|---|---|
-| Disconnected continuity | No unintended short on the documented supply or RF paths | Unexpected continuity or uncertain meter setup |
-| Connector polarity | Measurements match the reviewed schematic and manufacturer pinout | Any disagreement or unknown pin |
-| Solar, battery, and output values | Each measured value is within every connected component's current documentation | Missing limit or out-of-range value |
-| First power | Stable expected startup with no heat, odour, swelling, smoke, noise, or cycling | Any abnormal physical or electrical behaviour |
-| RF path | Correct band, filter direction, connections, and attached antenna before transmit | Missing antenna, loose/forced connector, unknown filter response |
-| Optional telemetry | Independently reproduced measurement and firmware behaviour | Unverified wiring, address, calibration, or build target |
+| Channel | Connected To | Purpose |
+|---------|--------------|---------|
+| CH1 | Battery | Monitor battery voltage and current draw |
+| CH2 | (unused) | Available for future use |
+| CH3 | Solar | Monitor solar input voltage and charging current |
 
 </div>
 
-## Test it on the bench
+**Note:** VCC on the INA3221 is the board power pin (3.3V from the Ikoka). VIN1/VIN2/VIN3 are the measurement channel inputs, not the power pin.
 
-<ul class="mc-checklist">
-  <li>Record exact parts, revisions, source documents, schematic, photographs, polarity, and measured values.</li>
-  <li>Use supervised and current-limited first-power methods appropriate to the reviewed hardware.</li>
-  <li>Confirm the unit starts after each intended power source is applied and after a controlled power interruption.</li>
-  <li>Confirm the repeater's identity, firmware, radio, region, path, advert, and access settings survive reboot.</li>
-  <li>Confirm a nearby companion receives an advert and the planned local routing test succeeds.</li>
-  <li>Measure the RF/power behaviour using the reviewer's approved method; do not infer output from a firmware setting alone.</li>
-  <li>Run a supervised charge/load test that covers the reviewed conditions without exceeding component limits.</li>
-  <li>Inspect cable strain and seals, then complete an enclosure-appropriate water-resistance test.</li>
-  <li>Prove USB recovery and document the removal/access plan.</li>
-</ul>
+### Firmware build flags
 
-Do not deploy until a hardware/electrical reviewer, RF reviewer, and site owner approve the completed test record.
+MeshCore defaults to address `0x42`; the Adafruit INA3221 uses `0x40`. Keep the inherited board flags and add the sensor settings to the 30 dBm repeater environment:
 
-## Recovery and undo
+```ini
+[env:ikoka_stick_nrf_30dbm_repeater]
+build_flags =
+  ${ikoka_stick_nrf_repeater.build_flags}
+  ${ikoka_stick_nrf_e22_30dbm.build_flags}
+  -D TELEM_INA3221_ADDRESS=0x40
+  -UENV_INCLUDE_INA219
+  -D TELEM_INA3221_SHUNT_VALUE=0.05
+```
 
-If a check fails, stop transmitting and disconnect solar, USB, and battery power using the reviewed safe sequence. Move the equipment to a suitable supervised work area. Do not reconnect a warm, swollen, damaged, leaking, or otherwise questionable lithium battery. Restore firmware by USB only after the electrical/RF fault is understood.
+The address and INA219 flags are from the original guide: they select `0x40` and disable the conflicting INA219 driver. The shunt-value flag matches the Adafruit board's **0.05 Ω** resistors so current readings use the correct scale. See [Adafruit's pinout](https://learn.adafruit.com/adafruit-ina3221-breakout/pinouts) and [MeshCore's sensor defaults](https://github.com/meshcore-dev/MeshCore/blob/main/src/helpers/sensors/EnvironmentSensorManager.cpp).
 
-Cutouts, epoxy, removed pins, and solder bridges may be irreversible. Replace uncertain components rather than improvising a repair. The safe rollback from the optional telemetry branch is to omit it before modification, not to assume removed hardware can be restored.
+## Wiring diagram
 
-## Maintenance
+[![Wiring diagram](images/repeater-solar-1w-diy-build-9.svg){ .mc-build-photo .mc-build-diagram width="600" height="543" loading=lazy }](images/repeater-solar-1w-diy-build-9.svg)
 
-No interval is approved. The site record must define inspections for mounting, panel/bond, water entry, vent, seals, corrosion, cables/connectors, filter, battery condition, charge behaviour, measured values, firmware/configuration, radio verification, and physical recovery. Reinspect after any severe event or unexplained behaviour defined by the site reviewer.
+<span id="test-it-on-the-bench"></span>
+
+## Check before powering on { #check-the-readings }
+
+- Check polarity and continuity, then inspect solder joints for shorts.
+- Use a protected, matched 1S battery pack and stay within the cells' charging-temperature limits.
+- Confirm the antenna, filter, and RF cables are connected.
+- Check that the power manager supplies the expected USB voltage before connecting the radio.
+- Test that power returns after an interruption. If fitted, compare INA3221 readings with a multimeter.
+- [Flash and configure the repeater](../start/repeater.md), then check that a nearby companion receives its advert before installing it.
+
+## Troubleshooting and recovery { #recovery-and-undo }
+
+If the unit does not start, disconnect power and recheck the wiring and BOOT-button modification. Stop using any battery that is hot, swollen, leaking, or damaged. If a firmware change fails, use the [USB recovery steps](../meshcore/flash-repeater.md#recovery-plan) after checking the power and RF connections.
+
+<span id="maintenance"></span>
+
+After installation, check the mounting, panel bond, seals, vent, cables, and battery condition regularly and after severe weather.
 
 ## Source
 
-Based on experimental community notes contributed by MrAlders0n in 2026. No
-hardware or firmware claim on this page is verified.
+Restored from [MrAlders0n's pre-overhaul guide](https://github.com/MeshCore-ca/MeshCore-Canada/blob/76a4262a354a111d19ddf8cc4abb25b1267fd9db/docs/hardware/repeater-solar-1w-diy-build.md). The original parts, assembly sequence, photos, wiring tables, and downloads are retained. The optional telemetry example also includes the Adafruit shunt value.
 
-Prefer a reviewed option from the [repeater selection guide](recommended-repeaters.md).
-If this experiment is approved and commissioned, complete the
-[mounting plan](repeater-mounting-options.md) and
-[repeater configuration](../config/index.md).
+For the standard power manager's limits and connector markings, see the [Waveshare manual](https://files.waveshare.com/upload/6/6c/Solar_Power_Manager_user_manual_en.pdf).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -133,7 +133,7 @@ plugins:
             Antennas: Antennes
             Solar repeater build: Répéteur solaire
             Build a 300 mW repeater: Monter un répéteur de 300 mW
-            Build a 1 W repeater (experimental): Monter un répéteur de 1 W (expérimental)
+            Build a 1 W repeater: Monter un répéteur de 1 W
             Wire connector types: Types de connecteurs de fils
             Install a repeater: Installer un répéteur
             Mounting options: Options de montage
@@ -242,7 +242,7 @@ nav:
       - Antennas: hardware/recommended-antenna.md
       - Solar repeater build:
           - Build a 300 mW repeater: hardware/repeater-solar-300mw-diy-build.md
-          - Build a 1 W repeater (experimental): hardware/repeater-solar-1w-diy-build.md
+          - Build a 1 W repeater: hardware/repeater-solar-1w-diy-build.md
           - Wire connector types: hardware/wire-connector-types.md
       - Install a repeater:
           - Mounting options: hardware/repeater-mounting-options.md

--- a/tests/browser/critical-journeys.spec.mjs
+++ b/tests/browser/critical-journeys.spec.mjs
@@ -174,16 +174,16 @@ test("English and French homepages link directly to the region finder", async ({
   }
 });
 
-test("hardware landing links directly to the experimental 1 W build", async ({ page }, testInfo) => {
+test("hardware landing links directly to the restored 1 W build", async ({ page }, testInfo) => {
   await page.goto(siteRoute("/hardware/"));
-  const link = page.getByRole("link", { name: "Review the experimental 1 W build" });
+  const link = page.getByRole("link", { name: "Read the 1 W build guide" });
   await expect(link).toBeVisible();
   await expect(link).toHaveAttribute("href", "repeater-solar-1w-diy-build/");
   await link.click();
   await expect(page).toHaveURL(
     resolveSiteRoute(testInfo.project.use.baseURL, "/hardware/repeater-solar-1w-diy-build/"),
   );
-  await expect(page.getByRole("heading", { level: 1 })).toContainText("Experimental 1 W Solar Repeater");
+  await expect(page.getByRole("heading", { level: 1 })).toContainText("Building a 1 W solar repeater — Ikoka Stick");
 });
 
 test("config place deep links resolve an online city search", async ({ page }) => {

--- a/tests/browser/restored-1w-guide.spec.mjs
+++ b/tests/browser/restored-1w-guide.spec.mjs
@@ -11,6 +11,7 @@ for (const locale of ["", "fr/"]) {
     await expect(parts.locator("tbody tr")).toHaveCount(16);
     await expect(parts).toContainText("M3x35");
     await expect(parts).toContainText("M3x5");
+    expect(await parts.evaluate(table => parseFloat(getComputedStyle(table).fontSize))).toBeGreaterThanOrEqual(16);
     expect(await parts.locator("tbody td").first().evaluate(cell => parseFloat(getComputedStyle(cell).paddingLeft))).toBeGreaterThanOrEqual(8);
     await expect(page.locator('article a[href$=".3mf"]')).toHaveCount(1);
     await expect(page.locator('article a[href$=".stl"]')).toHaveCount(2);

--- a/tests/browser/restored-1w-guide.spec.mjs
+++ b/tests/browser/restored-1w-guide.spec.mjs
@@ -1,0 +1,48 @@
+import { expect, test } from "./site-fixtures.mjs";
+import AxeBuilder from "@axe-core/playwright";
+import { siteRoute } from "./site-route.mjs";
+
+for (const locale of ["", "fr/"]) {
+  test(`${locale || "en/"} restored 1 W guide has usable parts, photos, wiring, and downloads`, async ({ page }) => {
+    await page.goto(siteRoute(`/${locale}hardware/repeater-solar-1w-diy-build/`));
+    await expect(page.locator("h1")).toContainText("Ikoka Stick");
+    await expect(page.locator(".mc-guide-status, .mc-page-status")).toHaveCount(0);
+    const parts = page.locator(".mc-table-wrap table").first();
+    await expect(parts.locator("tbody tr")).toHaveCount(16);
+    await expect(parts).toContainText("M3x35");
+    await expect(parts).toContainText("M3x5");
+    expect(await parts.locator("tbody td").first().evaluate(cell => parseFloat(getComputedStyle(cell).paddingLeft))).toBeGreaterThanOrEqual(8);
+    await expect(page.locator('article a[href$=".3mf"]')).toHaveCount(1);
+    await expect(page.locator('article a[href$=".stl"]')).toHaveCount(2);
+    const assemblyCount = await page.locator("#assembly-steps").evaluate(heading => {
+      let count = 0;
+      for (let element = heading.nextElementSibling; element && element.tagName !== "H2"; element = element.nextElementSibling) {
+        if (element.tagName === "OL") count += element.children.length;
+      }
+      return count;
+    });
+    expect(assemblyCount).toBe(28);
+    const photos = page.locator("img.mc-build-photo");
+    await expect(photos).toHaveCount(9);
+    for (const photo of await photos.all()) {
+      await expect(photo).toHaveAttribute("width", /^[1-9]\d+$/);
+      await expect(photo).toHaveAttribute("height", /^[1-9]\d+$/);
+      await photo.scrollIntoViewIfNeeded();
+      await expect.poll(() => photo.evaluate(image => image.complete && image.naturalWidth > 0)).toBe(true);
+      expect(await photo.locator("..").getAttribute("href")).toMatch(/repeater-solar-1w-diy-build-\d+\.(jpg|svg)$/);
+    }
+    await expect(page.locator("pre")).toContainText("TELEM_INA3221_ADDRESS=0x40");
+    await expect(page.locator("pre")).toContainText("TELEM_INA3221_SHUNT_VALUE=0.05");
+    const diagram = page.locator(".mc-build-diagram");
+    await expect(diagram).toHaveCSS("background-color", "rgb(255, 255, 255)");
+    const layout = await page.evaluate(() => ({ width: document.documentElement.clientWidth, content: document.documentElement.scrollWidth }));
+    expect(layout.content).toBeLessThanOrEqual(layout.width + 1);
+  });
+
+  test(`${locale || "en/"} restored 1 W guide remains accessible`, async ({ page }) => {
+    await page.goto(siteRoute(`/${locale}hardware/repeater-solar-1w-diy-build/`));
+    await expect(page.locator(".mc-build-table table").first()).toHaveClass(/mc-table--responsive/);
+    const audit = await new AxeBuilder({ page }).include("article").withTags(["wcag2a", "wcag2aa", "wcag21aa"]).analyze();
+    expect(audit.violations).toEqual([]);
+  });
+}

--- a/tests/content/devices-builds.test.mjs
+++ b/tests/content/devices-builds.test.mjs
@@ -93,10 +93,9 @@ test("recommendation pages state compatibility and current-purchase limits", () 
   }
 });
 
-test("build guides provide staged, printable safety checks and records", () => {
+test("the 300 mW draft retains its staged safety checks and records", () => {
   for (const path of [
     "docs/hardware/repeater-solar-300mw-diy-build.md",
-    "docs/hardware/repeater-solar-1w-diy-build.md",
   ]) {
     const source = read(path);
     for (const phrase of [
@@ -125,7 +124,7 @@ test("the 1 W build is listed in navigation while legacy workflows stay outside 
 
   assert.match(
     config,
-    /Build a 1 W repeater \(experimental\): hardware\/repeater-solar-1w-diy-build\.md/,
+    /Build a 1 W repeater: hardware\/repeater-solar-1w-diy-build\.md/,
   );
   assert.match(config, /Wire connector types: hardware\/wire-connector-types\.md/);
   assert.doesNotMatch(config, /generate-repeater-id\.md/);
@@ -140,8 +139,9 @@ test("hardware landing makes both solar build guides easy to find", () => {
   for (const source of [overview, repeaters]) {
     assert.match(source, /repeater-solar-300mw-diy-build\//);
     assert.match(source, /repeater-solar-1w-diy-build\//);
-    assert.match(source, /Experimental 1 W solar repeater/);
-    assert.match(source, /electrical, RF, and site review/i);
+    assert.match(source, /1 W solar repeater — Ikoka Stick/);
+    assert.match(source, /Read the 1 W build guide/);
+    assert.match(source, /assembly photos, wiring, and optional INA3221/);
   }
 });
 

--- a/tests/content/restored-1w-guide.test.mjs
+++ b/tests/content/restored-1w-guide.test.mjs
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import { existsSync, readFileSync } from "node:fs";
+import test from "node:test";
+
+const sourceRevision = "76a4262a354a111d19ddf8cc4abb25b1267fd9db";
+const pages = ["docs/hardware/repeater-solar-1w-diy-build.md", "docs/hardware/repeater-solar-1w-diy-build.fr.md"];
+const downloads = ["plate-and-battery-holder.3mf", "plate.stl", "3x18650-battery-holder.stl"];
+
+for (const path of pages) {
+  const source = readFileSync(path, "utf8");
+  test(`${path} preserves the original contributor, parts, steps, and illustrations`, () => {
+    assert.match(source, /MrAlders0n \(Ottawa\)/);
+    assert.ok(source.includes(sourceRevision), "Link to the exact pre-overhaul source");
+    assert.match(source, /January 1, 2026|1er janvier 2026/);
+    assert.match(source, /^scope: ottawa-field-practice$/m);
+    assert.match(source, /^status: draft$/m);
+    const steps = [...source.matchAll(/^(\d+)\. /gm)].map(match => Number(match[1]));
+    assert.deepEqual(steps, Array.from({ length: 28 }, (_, i) => i + 1));
+    const parts = [...source.matchAll(/^\| (\d+) \|/gm)].map(match => Number(match[1]));
+    assert.deepEqual(parts, Array.from({ length: 16 }, (_, i) => i + 1));
+    for (let i = 1; i <= 9; i++) {
+      const file = `repeater-solar-1w-diy-build-${i}.${i === 9 ? "svg" : "jpg"}`;
+      assert.ok(source.includes(`images/${file}`), `${file} must remain visible`);
+      assert.ok(existsSync(`docs/hardware/images/${file}`));
+    }
+    for (const ending of downloads) {
+      const file = `repeater-solar-1w-diy-build-${ending}`;
+      assert.ok(source.includes(`files/${file}`), `${file} must remain downloadable`);
+      assert.ok(existsSync(`docs/hardware/files/${file}`));
+    }
+    assert.match(source, /mc-table-wrap/);
+    assert.match(source, /mc-build-diagram/);
+  });
+
+  test(`${path} retains the useful prices, quantities, wiring, and firmware values`, () => {
+    assert.match(source, /280[-–]290/);
+    assert.match(source, /300[-–]310/);
+    assert.match(source, /M3x35[^\n]*\| 4 \|/);
+    assert.match(source, /M3x5[^\n]*\| 8 \|/);
+    for (const term of ["0.4.0", "Callboost", "Alfa", "JST PH2.0", "CH1+", "CH1-", "CH3+", "CH3-", "BOOT", "GND", "VCC", "SCL", "SDA"]) {
+      assert.ok(source.includes(term), `${term} is restored build data`);
+    }
+    assert.match(source, /6[-–]8 dBi/);
+    assert.match(source, /5[.,]8 dBi/);
+    assert.match(source, /ikoka_stick_nrf_30dbm_repeater/);
+    assert.match(source, /\$\{ikoka_stick_nrf_repeater\.build_flags\}/);
+    assert.match(source, /\$\{ikoka_stick_nrf_e22_30dbm\.build_flags\}/);
+    assert.match(source, /-D TELEM_INA3221_ADDRESS=0x40/);
+    assert.match(source, /-UENV_INCLUDE_INA219/);
+    assert.match(source, /-D TELEM_INA3221_SHUNT_VALUE=0\.05/);
+    assert.ok(source.includes("https://www.aliexpress.com/item/1005004468960058.html"), "Alternative filter source");
+    assert.ok(source.includes("https://www.alibaba.com/product-detail/50W-890-960MHz-4-Cavity-Filter_1601399651944.html"));
+    assert.match(source, /No warranty|Sans garantie/);
+    assert.match(source, /Antenna required|Antenne obligatoire/);
+    assert.match(source, /^destructive: true$/m);
+    assert.doesNotMatch(source, /Do not build or deploy this design|Default:.*omit optional telemetry|No hardware or firmware claim|Ne construisez et ne déployez pas ce modèle/);
+  });
+}
+
+test("both restored guides use the same telemetry build configuration", () => {
+  const blocks = pages.map(path => readFileSync(path, "utf8").match(/```ini\n([\s\S]*?)\n```/)?.[1]);
+  assert.ok(blocks[0]);
+  assert.equal(blocks[0], blocks[1]);
+});


### PR DESCRIPTION
## Restore the useful build guide

Restores MrAlders0n's [pre-overhaul 1 W Ikoka Stick guide](https://github.com/MeshCore-ca/MeshCore-Canada/blob/76a4262a354a111d19ddf8cc4abb25b1267fd9db/docs/hardware/repeater-solar-1w-diy-build.md), using the version on main immediately before #66 merged.

- All 16 parts, original prices and totals, exact fastener quantities, supplier links, alternate filter, and Ottawa antenna observations.
- All 28 assembly steps, eight build photos, the wiring diagram, and three printable downloads. The image and download files themselves are unchanged.
- Optional INA3221 pinout, solar/battery wiring, channel assignments, and firmware flags.
- Matching French content, clear navigation/card labels, readable tables, full-size image links, and reserved image space to avoid layout shifts.

Removes the blanket “experimental/unverified” language and repeated approval gates that replaced the practical instructions. Keeps concise warranty, antenna, polarity, battery, and disconnected-power precautions. This is a documentation restoration, not a claim of new hardware testing.

## Small clarifications

Prices are explicitly dated to the original January 1, 2026 guide. The BOOT-button modification is scoped to the standard Waveshare model. The original INA3221 address and driver flags are retained; the example also specifies the Adafruit board's documented 0.05-ohm shunts, matching the configurable value in the current MeshCore sensor code. Manufacturer and upstream references are linked in the guide.

## Validation

- 171 Node content/editor checks and 16 Python content checks pass.
- Strict bilingual build and local link checks pass across 129 pages and 13,304 references.
- All 24 targeted browser checks pass on the public preview, covering the restored steps, images, tables, downloads, mobile layout, and accessibility in both languages across six browser configurations.
- All nine original images match the served files byte-for-byte; all three printable downloads are available. The changed HTML and stylesheet match the built artifact.
- [Full CI run](https://github.com/MeshCore-ca/MeshCore-Canada/actions/runs/34407836962), including the complete browser matrix and unchanged Lighthouse budgets.

## Preview

[English guide](https://canadaverse.org/meshcore-canada/hardware/repeater-solar-1w-diy-build/) · [French guide](https://canadaverse.org/meshcore-canada/fr/hardware/repeater-solar-1w-diy-build/)

The [public manifest](https://canadaverse.org/meshcore-canada/site-manifest.json) identifies `caed58631f6d84f7c4dc6fcf166951393802febf`. The preview remains excluded from indexing. The previous release is retained for rollback; no server restart or configuration change was needed. The main Canadaverse homepage and meshcore.ca remain unchanged. This PR has not been merged.
